### PR TITLE
Improve loading a DLS file and searching for instruments in it

### DIFF
--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -1613,7 +1613,17 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     if (bank & 0x7fff8080)
     {
         { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08lx\n", bank); */ }
-        bank &= 0xff7f;
+    }
+    if (bank & 0x80000000u)
+    {
+        /* drum instrument */
+        bank &= 0x7f7f;
+        bank |= 0x10000;
+    }
+    else
+    {
+        /* melodic instrument */
+        bank &= 0x7f7f;
     }
     if (program > 127)
     {


### PR DESCRIPTION
The embedded samples aren't very good, so I wanted to load a DLS file (using function EAS_LoadDLSCollection) to improve the quality, but some of the DLS file that I test weren't loaded and when a DLS file was loaded then the synthesizer was still using the embedded samples instead of samples from the DLS file.

So I made some changes to improve it:
* increase some limits to allow loading some DLS files which couldn't be loaded before
* differentiate between melodic and drum instruments when loading DLS file and when searching for instruments in DLS file
* improve searching for instruments in DLS file, with fallbacks to defaults for missing instruments