### PR TITLE
Fix CVE-2024-23709

### DIFF
--- a/arm-wt-22k/lib_src/eas_wtengine.c
+++ b/arm-wt-22k/lib_src/eas_wtengine.c
@@ -99,6 +99,10 @@ void WT_VoiceGain (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
     pMixBuffer = pWTIntFrame->pMixBuffer;
     pInputBuffer = pWTIntFrame->pAudioBuffer;
@@ -196,6 +200,10 @@ void WT_Interpolate (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
     pOutputBuffer = pWTIntFrame->pAudioBuffer;
 
@@ -297,6 +305,10 @@ void WT_InterpolateNoLoop (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
     pOutputBuffer = pWTIntFrame->pAudioBuffer;
 
@@ -397,6 +409,10 @@ void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
     pAudioBuffer = pWTIntFrame->pAudioBuffer;
 
@@ -465,6 +481,10 @@ void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
     pOutputBuffer = pWTIntFrame->pAudioBuffer;
     phaseInc = pWTIntFrame->frame.phaseIncrement;
@@ -613,6 +633,10 @@ void WT_InterpolateMono (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
     pMixBuffer = pWTIntFrame->pMixBuffer;
 


### PR DESCRIPTION
<https://nvd.nist.gov/vuln/detail/CVE-2024-23709>
<https://android.googlesource.com/platform/external/sonivox/+/f9d489385ecb04bbfe06f92d6fb03a69d2734fad>

cherry-picked from f9d489385ecb04bbfe06f92d6fb03a69d2734fad

```
fix buffer overrun in eas_wtengine

avoid a buffer overrun in eas_wtengine.
Check buffer limits during application of gain
Clip calculated length in eas_wtsynth

Bug: 317780080
Test: POC with bug
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:6b66e7665dbcd891ff23081c13ab0b1637bb1dda)
Merged-In: I3609d6a36d89b26ae7eb3ae84cbe7772f6c3bee0
Change-Id: I3609d6a36d89b26ae7eb3ae84cbe7772f6c3bee0
backporting fix from main
```