### PR TITLE
The new host wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(BUILD_SONIVOX_SHARED "Build the shared library" TRUE)
 option(BUILD_EXAMPLE "Build and install the example program" TRUE)
 option(BUILD_TESTING "Build the unit tests" TRUE)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Whether to create position-independent targets" TRUE)
+option(USE_NEW_HOST_WRAPPER "Use the new host wrapper" TRUE)
 set(MAX_VOICES 64 CACHE STRING "Maximum number of voices")
 
 include(CMakeDependentOption)
@@ -67,7 +68,7 @@ endif()
 
 list(APPEND SOURCES
   arm-wt-22k/host_src/eas_config.c
-  arm-wt-22k/host_src/eas_hostmm.c
+#arm-wt-22k/host_src/eas_hostmm.c
 #arm-wt-22k/host_src/eas_main.c
   arm-wt-22k/host_src/eas_report.c
 #arm-wt-22k/host_src/eas_wave.c
@@ -110,6 +111,12 @@ list(APPEND SOURCES
 #arm-wt-22k/lib_src/jet.c
   arm-wt-22k/lib_src/wt_200k_G.c
 )
+
+if (USE_NEW_HOST_WRAPPER)
+    list(APPEND SOURCES arm-wt-22k/src/hostmm_ng.c)
+else()
+    list(APPEND SOURCES arm-wt-22k/host_src/eas_hostmm.c)
+endif()
 
 configure_file(arm-wt-22k/host_src/eas.cmake libsonivox/eas.h @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(BUILD_SONIVOX_SHARED "Build the shared library" TRUE)
 option(BUILD_EXAMPLE "Build and install the example program" TRUE)
 option(BUILD_TESTING "Build the unit tests" TRUE)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Whether to create position-independent targets" TRUE)
-option(USE_NEW_HOST_WRAPPER "Use the new host wrapper" TRUE)
+option(NEW_HOST_WRAPPER "Use the new host wrapper" TRUE)
 set(MAX_VOICES 64 CACHE STRING "Maximum number of voices")
 
 include(CMakeDependentOption)
@@ -112,7 +112,7 @@ list(APPEND SOURCES
   arm-wt-22k/lib_src/wt_200k_G.c
 )
 
-if (USE_NEW_HOST_WRAPPER)
+if (NEW_HOST_WRAPPER)
     list(APPEND SOURCES arm-wt-22k/src/hostmm_ng.c)
 else()
     list(APPEND SOURCES arm-wt-22k/host_src/eas_hostmm.c)
@@ -145,6 +145,13 @@ target_compile_definitions( sonivox-objects PRIVATE
   #_XMF_PARSER
   #JET_INTERFACE
 )
+
+include(TestBigEndian)
+test_big_endian(BIG_ENDIAN)
+
+if (BIG_ENDIAN) 
+    target_compile_definitions( sonivox-objects PRIVATE EAS_BIG_ENDIAN )
+endif()
 
 if (USE_16BITS_SAMPLES)
     target_compile_definitions( sonivox-objects PRIVATE

--- a/arm-wt-22k/host_src/eas.cmake
+++ b/arm-wt-22k/host_src/eas.cmake
@@ -46,6 +46,8 @@ extern "C" {
 #define MAKE_LIB_VERSION(a,b,c,d) (((((((EAS_U32) a <<8) | (EAS_U32) b) << 8) | (EAS_U32) c) << 8) | (EAS_U32) d)
 #define LIB_VERSION MAKE_LIB_VERSION(@PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,@PROJECT_VERSION_TWEAK@)
 
+#cmakedefine NEW_HOST_WRAPPER
+
 typedef struct
 {
     EAS_U32     libVersion;

--- a/arm-wt-22k/src/hostmm_ng.c
+++ b/arm-wt-22k/src/hostmm_ng.c
@@ -2,20 +2,23 @@
 // This implements EAS Host Wrapper, using C runtime library, with better performance
 
 #include "eas_host.h"
-#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <linux/limits.h>
 #include <pthread.h>
-#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if defined (__linux__)
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#elif defined (_WIN32)
+#include <io.h>
+#include <windows.h>
+#endif
 
 /* Only for debugging LED, vibrate, and backlight functions */
 #include "eas_report.h"
@@ -242,6 +245,43 @@ EAS_RESULT EAS_HWDupHandle(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, 
 
     *pDupFile = new_file;
     return EAS_SUCCESS;
+#elif defined (_WIN32)
+    char pathName[MAX_PATH];
+    int fd = _fileno(file->handle);
+    if (fd == -1) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+    HANDLE hnd = (HANDLE)_get_osfhandle(fd);
+    if (hnd == INVALID_HANDLE_VALUE) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+    
+    if (GetFinalPathNameByHandle(hnd, pathName, MAX_PATH, 0) == 0) {
+        return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
+    }
+
+    EAS_HW_FILE* new_file = malloc(sizeof(EAS_HW_FILE));
+    new_file->handle = fopen(pathName, "rb"); // always dup as rb, should be okay   
+    new_file->own = EAS_TRUE;
+    if (new_file->handle == NULL) {
+        free(new_file);
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+    
+    long pos = ftell(file->handle);
+    if (pos == -1) {
+        fclose(new_file->handle);
+        free(new_file);
+        return EAS_ERROR_FILE_POS;
+    }
+    if (fseek(new_file->handle, pos, SEEK_SET) != 0) {
+        fclose(new_file->handle);
+        free(new_file);
+        return EAS_ERROR_FILE_SEEK;
+    }
+
+    *pDupFile = new_file;
+    return EAS_SUCCESS; 
 #endif
 }
 

--- a/arm-wt-22k/src/hostmm_ng.c
+++ b/arm-wt-22k/src/hostmm_ng.c
@@ -1,0 +1,288 @@
+// hostmm_ng.c
+// This implements EAS Host Wrapper, using C runtime library, with better performance
+
+#include "eas_host.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <linux/limits.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Only for debugging LED, vibrate, and backlight functions */
+#include "eas_report.h"
+
+#if __has_include(<byteswap.h>)
+#include <byteswap.h>
+#define bswap16 __bswap_16
+#define bswap32 __bswap_32
+#elif defined(_MSC_VER)
+#define bswap16 _byteswap_ushort
+#define bswap32 _byteswap_ulong
+#elif defined(__GNUC__) || defined(__clang__)
+#define bswap16 __builtin_bswap16
+#define bswap32 __builtin_bswap32
+#endif
+
+// https://stackoverflow.com/a/2103095
+// CC BY-SA 3.0
+enum {
+    O32_LITTLE_ENDIAN = 0x03020100ul,
+    O32_BIG_ENDIAN = 0x00010203ul,
+    O32_PDP_ENDIAN = 0x01000302ul, /* DEC PDP-11 (aka ENDIAN_LITTLE_WORD) */
+    O32_HONEYWELL_ENDIAN = 0x02030001ul /* Honeywell 316 (aka ENDIAN_BIG_WORD) */
+};
+
+static const union {
+    uint8_t bytes[4];
+    uint32_t value;
+} o32_host_order = { { 0, 1, 2, 3 } };
+
+#define O32_HOST_ORDER (o32_host_order.value)
+// --- end
+
+typedef struct eas_hw_file_tag {
+    FILE* handle;
+    EAS_BOOL own;
+} EAS_HW_FILE;
+
+EAS_RESULT EAS_HWInit(EAS_HW_DATA_HANDLE* pHWInstData)
+{
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWShutdown(EAS_HW_DATA_HANDLE hwInstData)
+{
+    return EAS_SUCCESS;
+}
+
+void* EAS_HWMalloc(EAS_HW_DATA_HANDLE hwInstData, EAS_I32 size)
+{
+    return malloc((size_t)size);
+}
+
+void EAS_HWFree(EAS_HW_DATA_HANDLE hwInstData, void* p)
+{
+    free(p);
+}
+
+void* EAS_HWMemCpy(void* dest, const void* src, EAS_I32 amount)
+{
+    return memcpy(dest, src, (size_t)amount);
+}
+
+void* EAS_HWMemSet(void* dest, int val, EAS_I32 amount)
+{
+    return memset(dest, val, (size_t)amount);
+}
+
+EAS_I32 EAS_HWMemCmp(const void* s1, const void* s2, EAS_I32 amount)
+{
+    return (EAS_I32)memcmp(s1, s2, (size_t)amount);
+}
+
+EAS_RESULT EAS_HWOpenFile(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_LOCATOR locator, EAS_FILE_HANDLE* pFile, EAS_FILE_MODE mode)
+{
+    if (pFile == NULL) {
+        return EAS_ERROR_INVALID_PARAMETER;
+    }
+    *pFile = malloc(sizeof(EAS_HW_FILE));
+    (*pFile)->handle = locator->handle;
+    (*pFile)->own = EAS_FALSE;
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWReadFile(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, void* pBuffer, EAS_I32 n, EAS_I32* pBytesRead)
+{
+    /* make sure we have a valid handle */
+    if (file->handle == NULL) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+
+    size_t count = fread(pBuffer, 1, n, file->handle);
+    if (pBytesRead != NULL) {
+        *pBytesRead = count;
+    }
+
+    if (feof(file->handle)) {
+        return EAS_EOF;
+    }
+    if (ferror(file->handle)) {
+        return EAS_ERROR_FILE_READ_FAILED;
+    }
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWGetByte(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, void* p)
+{
+    return EAS_HWReadFile(hwInstData, file, p, 1, NULL);
+}
+
+EAS_RESULT EAS_HWGetWord(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, void* p, EAS_BOOL msbFirst)
+{
+    EAS_U16 word;
+    *((EAS_U16*)p) = 0;
+    EAS_RESULT result = EAS_HWReadFile(hwInstData, file, &word, 2, NULL);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+
+    if (msbFirst ^ (O32_HOST_ORDER == O32_BIG_ENDIAN)) {
+        *((EAS_U16*)p) = bswap16(word);
+    } else {
+        *((EAS_U16*)p) = word;
+    }
+    return EAS_SUCCESS;
+}
+
+/*lint -esym(715, hwInstData) hwInstData available for customer use */
+EAS_RESULT EAS_HWGetDWord(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, void* p, EAS_BOOL msbFirst)
+{
+    uint32_t dword; // EAS_U32 is not uint32_t
+    *((EAS_U32*)p) = 0;
+    EAS_RESULT result = EAS_HWReadFile(hwInstData, file, &dword, 4, NULL);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+
+    if (msbFirst ^ (O32_HOST_ORDER == O32_BIG_ENDIAN)) {
+        *((EAS_U32*)p) = bswap32(dword);
+    } else {
+        *((EAS_U32*)p) = dword;
+    }
+
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWFilePos(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, EAS_I32* pPosition)
+{
+    /* make sure we have a valid handle */
+    if (file->handle == NULL) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+
+    long pos = ftell(file->handle);
+    if (pPosition != NULL) {
+        *pPosition = pos;
+    }
+    return EAS_SUCCESS;
+} /* end EAS_HWFilePos */
+
+EAS_RESULT EAS_HWFileSeek(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, EAS_I32 position)
+{
+    /* make sure we have a valid handle */
+    if (file->handle == NULL) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+
+    /* validate new position */
+    if (fseek(file->handle, position, SEEK_SET) != 0) {
+        return EAS_ERROR_FILE_SEEK;
+    }
+
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWFileSeekOfs(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, EAS_I32 position)
+{
+    /* make sure we have a valid handle */
+    if (file->handle == NULL) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+
+    if (fseek(file->handle, position, SEEK_CUR) != 0) {
+        return EAS_ERROR_FILE_SEEK;
+    }
+
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWDupHandle(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, EAS_FILE_HANDLE* pDupFile)
+{
+    *pDupFile = NULL;
+#if defined(__linux__) // todo: implement for other platforms
+    char filePath[PATH_MAX];
+    char linkPath[PATH_MAX];
+
+    snprintf(linkPath, PATH_MAX, "/proc/self/fd/%d", fileno(file->handle));
+
+    ssize_t len = readlink(linkPath, filePath, PATH_MAX);
+    if (len == -1) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+    filePath[len] = '\0';
+
+    EAS_HW_FILE* new_file = malloc(sizeof(EAS_HW_FILE));
+    new_file->handle = fopen(filePath, "rb"); // always dup as rb, should be okay
+    new_file->own = EAS_TRUE;
+    if (new_file->handle == NULL) {
+        free(new_file);
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+
+    long pos = ftell(file->handle);
+    if (pos == -1) {
+        fclose(new_file->handle);
+        free(new_file);
+        return EAS_ERROR_FILE_POS;
+    }
+    if (fseek(new_file->handle, pos, SEEK_SET) != 0) {
+        fclose(new_file->handle);
+        free(new_file);
+        return EAS_ERROR_FILE_SEEK;
+    }
+
+    *pDupFile = new_file;
+    return EAS_SUCCESS;
+#endif
+}
+
+EAS_RESULT EAS_HWCloseFile(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file)
+{
+    /* make sure we have a valid handle */
+    if (file->handle == NULL) {
+        return EAS_ERROR_INVALID_HANDLE;
+    }
+
+    if (file->own) {
+        if (fclose(file->handle) != 0) {
+            return EAS_ERROR_INVALID_HANDLE;
+        }
+    }
+    
+    free(file);
+
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWVibrate(EAS_HW_DATA_HANDLE hwInstData, EAS_BOOL state)
+{
+    EAS_ReportEx(_EAS_SEVERITY_NOFILTER, 0x1a54b6e8, 0x00000001, state);
+    return EAS_SUCCESS;
+} /* end EAS_HWVibrate */
+
+EAS_RESULT EAS_HWLED(EAS_HW_DATA_HANDLE hwInstData, EAS_BOOL state)
+{
+    EAS_ReportEx(_EAS_SEVERITY_NOFILTER, 0x1a54b6e8, 0x00000002, state);
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT EAS_HWBackLight(EAS_HW_DATA_HANDLE hwInstData, EAS_BOOL state)
+{
+    EAS_ReportEx(_EAS_SEVERITY_NOFILTER, 0x1a54b6e8, 0x00000003, state);
+    return EAS_SUCCESS;
+}
+
+EAS_BOOL EAS_HWYield(EAS_HW_DATA_HANDLE hwInstData)
+{
+    // just let it run
+    return EAS_FALSE;
+}

--- a/arm-wt-22k/src/hostmm_ng.c
+++ b/arm-wt-22k/src/hostmm_ng.c
@@ -35,22 +35,12 @@
 #define bswap32 __builtin_bswap32
 #endif
 
-// https://stackoverflow.com/a/2103095
-// CC BY-SA 3.0
-enum {
-    O32_LITTLE_ENDIAN = 0x03020100ul,
-    O32_BIG_ENDIAN = 0x00010203ul,
-    O32_PDP_ENDIAN = 0x01000302ul, /* DEC PDP-11 (aka ENDIAN_LITTLE_WORD) */
-    O32_HONEYWELL_ENDIAN = 0x02030001ul /* Honeywell 316 (aka ENDIAN_BIG_WORD) */
-};
-
-static const union {
-    uint8_t bytes[4];
-    uint32_t value;
-} o32_host_order = { { 0, 1, 2, 3 } };
-
-#define O32_HOST_ORDER (o32_host_order.value)
-// --- end
+const EAS_BOOL O32_BIG_ENDIAN = 
+#ifdef EAS_BIG_ENDIAN
+    EAS_TRUE;
+#else
+    EAS_FALSE;
+#endif
 
 typedef struct eas_hw_file_tag {
     void* handle;
@@ -157,7 +147,7 @@ EAS_RESULT EAS_HWGetWord(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, vo
         return result;
     }
 
-    if (msbFirst ^ (O32_HOST_ORDER == O32_BIG_ENDIAN)) {
+    if (msbFirst ^ O32_BIG_ENDIAN) {
         *((EAS_U16*)p) = bswap16(word);
     } else {
         *((EAS_U16*)p) = word;
@@ -175,7 +165,7 @@ EAS_RESULT EAS_HWGetDWord(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, v
         return result;
     }
 
-    if (msbFirst ^ (O32_HOST_ORDER == O32_BIG_ENDIAN)) {
+    if (msbFirst ^ O32_BIG_ENDIAN) {
         *((EAS_U32*)p) = bswap32(dword);
     } else {
         *((EAS_U32*)p) = dword;

--- a/arm-wt-22k/src/hostmm_ng.c
+++ b/arm-wt-22k/src/hostmm_ng.c
@@ -271,6 +271,7 @@ EAS_RESULT EAS_HWDupHandle(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, 
     filePath[len] = '\0';
 
     EAS_HW_FILE* new_file = malloc(sizeof(EAS_HW_FILE));
+    memset(new_file, 0, sizeof(EAS_HW_FILE));
     new_file->handle = fopen(filePath, "rb"); // always dup as rb, should be okay
     new_file->own = EAS_TRUE;
     if (new_file->handle == NULL) {
@@ -308,6 +309,7 @@ EAS_RESULT EAS_HWDupHandle(EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE file, 
     }
 
     EAS_HW_FILE* new_file = malloc(sizeof(EAS_HW_FILE));
+    memset(new_file, 0, sizeof(EAS_HW_FILE));
     new_file->handle = fopen(pathName, "rb"); // always dup as rb, should be okay   
     new_file->own = EAS_TRUE;
     if (new_file->handle == NULL) {

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -38,6 +38,7 @@ EAS_DATA_HANDLE mEASDataHandle = NULL;
 const S_EAS_LIB_CONFIG *mEASConfig = NULL;
 char sLibrary_version[16];
 
+#ifndef NEW_HOST_WRAPPER
 int Read(void *handle, void *buf, int offset, int size)
 {
     int ret;
@@ -56,6 +57,7 @@ int Size(void *handle) {
 
     return ftell((FILE *) handle);
 }
+#endif
 
 void initLibraryVersion()
 {

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -115,8 +115,10 @@ int initializeLibrary(void)
             goto cleanup;
         }
 
-        // mDLSFile.readAt = Read;
-        // mDLSFile.size = Size;
+#ifndef NEW_HOST_WRAPPER
+        mDLSFile.readAt = Read;
+        mDLSFile.size = Size;
+#endif
 
         result = EAS_LoadDLSCollection(mEASDataHandle, NULL, &mDLSFile);
         fclose(mDLSFile.handle);
@@ -220,8 +222,10 @@ int renderFile(const char *fileName)
         return ok;
     }
 
-    // mEasFile.readAt = Read;
-    // mEasFile.size = Size;
+#ifndef NEW_HOST_WRAPPER
+    mEasFile.readAt = Read;
+    mEasFile.size = Size;
+#endif
 
     EAS_RESULT result = EAS_OpenFile(mEASDataHandle, &mEasFile, &mEASStreamHandle);
     if (result != EAS_SUCCESS) {

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -106,6 +106,7 @@ int initializeLibrary(void)
 
     if (dls_path != NULL) {
         EAS_FILE mDLSFile;
+        memset(&mDLSFile, 0, sizeof(EAS_FILE));
 
         mDLSFile.handle = fopen(dls_path, "rb");
         if (mDLSFile.handle == NULL) {
@@ -114,8 +115,8 @@ int initializeLibrary(void)
             goto cleanup;
         }
 
-        mDLSFile.readAt = Read;
-        mDLSFile.size = Size;
+        // mDLSFile.readAt = Read;
+        // mDLSFile.size = Size;
 
         result = EAS_LoadDLSCollection(mEASDataHandle, NULL, &mDLSFile);
         fclose(mDLSFile.handle);
@@ -210,6 +211,8 @@ int renderFile(const char *fileName)
 
     int ok = EXIT_SUCCESS;
 
+    memset(&mEasFile, 0, sizeof(EAS_FILE));
+
     mEasFile.handle = fopen(fileName, "rb");
     if (mEasFile.handle == NULL) {
         fprintf(stderr, "Failed to open %s. error: %s\n", fileName, strerror(errno));
@@ -217,8 +220,8 @@ int renderFile(const char *fileName)
         return ok;
     }
 
-    mEasFile.readAt = Read;
-    mEasFile.size = Size;
+    // mEasFile.readAt = Read;
+    // mEasFile.size = Size;
 
     EAS_RESULT result = EAS_OpenFile(mEASDataHandle, &mEasFile, &mEASStreamHandle);
     if (result != EAS_SUCCESS) {


### PR DESCRIPTION
After profiling about DLS loading, I found EAS's HW was so slow about file operations. It was designed for twenty years ago.
So I reimplemented it, using CRT and some OS-specific APIs. The old one is preserved as optional.

It works on Linux and Windows now, *blazing fast* (compared than before).