### PR TITLE
Fix wt_200k_G.c "initializer element is not constant" error with GCC < 8.1

### DIFF
--- a/arm-wt-22k/lib_src/wt_200k_G.c
+++ b/arm-wt-22k/lib_src/wt_200k_G.c
@@ -99,19 +99,20 @@ const S_BANK eas_banks[] =
  *----------------------------------------------------------------------------
 */
 
+// Can't be a 'const EAS_U32' before GCC 8.1
 #ifdef _SAMPLE_RATE_44100
-const EAS_U32 sampleRate = 0xAC44;
+#define SAMPLE_RATE	0xAC44
 #else
-const EAS_U32 sampleRate = 0x5622;
+#define SAMPLE_RATE	0x5622
 #endif
 
 const S_EAS easSoundLib = {
     0x01534145,
 
 #if defined (_8_BIT_SAMPLES)
-    0x00100000 | sampleRate,
+    0x00100000 | SAMPLE_RATE,
 #else //_16_BIT_SAMPLES
-    0x00200000 | sampleRate,
+    0x00200000 | SAMPLE_RATE,
 #endif
 
     eas_banks,


### PR DESCRIPTION
Hello,

We use Sonivox as part of ScummVM, and I've hit the following build error with v3.6.14 when compiling with GCC 7.5.0:

```
[ 96%] Building C object CMakeFiles/sonivox-objects.dir/arm-wt-22k/lib_src/wt_200k_G.c.o
gcc-mp-7 -DDLS_SYNTHESIZER -DEAS_WT_SYNTH -DMAX_SYNTH_VOICES=64 -DNUM_OUTPUT_CHANNELS=2 -DUNIFIED_DEBUG_MESSAGES -D_16_BIT_SAMPLES -D_CHORUS_ENABLED -D_FILTER_ENABLED -D_REVERB_ENABLED -D_SAMPLE_RATE_44100 -I/src/sonivox-3.6.14/build/libsonivox -I/src/sonivox-3.6.14/arm-wt-22k/host_src -I/src/sonivox-3.6.14/arm-wt-22k/lib_src -I/src/sonivox-3.6.14/fakes -O2 -fPIC -Wno-unused-parameter -Wno-unused-value -Wno-unused-variable -Wno-unused-function -Wno-misleading-indentation -Wno-attributes -o CMakeFiles/sonivox-objects.dir/arm-wt-22k/lib_src/wt_200k_G.c.o -c /src/sonivox-3.6.14/arm-wt-22k/lib_src/wt_200k_G.c
/src/sonivox-3.6.14/arm-wt-22k/lib_src/wt_200k_G.c:114:5: error: initializer element is not constant
     0x00200000 | sampleRate,
     ^~~~~~~~~~
/src/sonivox-3.6.14/arm-wt-22k/lib_src/wt_200k_G.c:114:5: note: (near initialization for 'easSoundLib.libAttr')
```

See [this example on Godbolt](https://godbolt.org/z/68sdozsqz) for a minimal test with this environment.

This problem appears to have been introduced by PR #20; GCC didn't allow doing this before GCC 8.1, per https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69960#c18. (Clang allowed this syntax for a longer time.)

Using an `enum` instead of a `const EAS_U32` variable is enough to let it build with older GCC releases.