### PR TITLE
Fix bswap use on Android

### DIFF
--- a/arm-wt-22k/src/hostmm_ng.c
+++ b/arm-wt-22k/src/hostmm_ng.c
@@ -20,16 +20,16 @@
 /* Only for debugging LED, vibrate, and backlight functions */
 #include "eas_report.h"
 
-#if __has_include(<byteswap.h>)
+#if defined(__GNUC__) || defined(__clang__)
+#define bswap16 __builtin_bswap16
+#define bswap32 __builtin_bswap32
+#elif __has_include(<byteswap.h>)
 #include <byteswap.h>
 #define bswap16 bswap_16
 #define bswap32 bswap_32
 #elif defined(_MSC_VER)
 #define bswap16 _byteswap_ushort
 #define bswap32 _byteswap_ulong
-#elif defined(__GNUC__) || defined(__clang__)
-#define bswap16 __builtin_bswap16
-#define bswap32 __builtin_bswap32
 #endif
 
 const EAS_BOOL O32_BIG_ENDIAN = 

--- a/arm-wt-22k/src/hostmm_ng.c
+++ b/arm-wt-22k/src/hostmm_ng.c
@@ -22,8 +22,8 @@
 
 #if __has_include(<byteswap.h>)
 #include <byteswap.h>
-#define bswap16 __bswap_16
-#define bswap32 __bswap_32
+#define bswap16 bswap_16
+#define bswap32 bswap_32
 #elif defined(_MSC_VER)
 #define bswap16 _byteswap_ushort
 #define bswap32 _byteswap_ulong


### PR DESCRIPTION
Android uses Bionic libc which doesn't provide `__bswap_16` nor `__bswap_32` (see [byteswap.h](https://android.googlesource.com/platform/bionic/+/main/libc/include/byteswap.h)).
But byteswap.h provides public macros to use.

In addition, avoid using these calls when the compiler provides a builtin function (at least for GCC and Clang).