### PR TITLE
Add a-law/u-law decoder for dls

### DIFF
--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -125,6 +125,9 @@
 #include "eas_report.h"
 #include <string.h>
 
+// for a-law/u-law decoding
+#include "pcm_aulaw.h"
+
 //2 we should replace log10() function with fixed point routine in ConvertSampleRate()
 /* lint is choking on the ARM math.h file, so we declare the log10 function here */
 extern double log10(double x);
@@ -231,6 +234,7 @@ typedef struct
     EAS_U32 loopStart;
     EAS_U32 loopLength;
     EAS_U32 sampleRate;
+    EAS_U16 fmtTag;
     EAS_U16 bitsPerSample;
     EAS_I16 fineTune;
     EAS_U8  unityNote;
@@ -1201,10 +1205,16 @@ static EAS_RESULT Parse_fmt (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WSM
     /* get format tag */
     if ((result = EAS_HWGetWord(pDLSData->hwInstData, pDLSData->fileHandle, &wtemp, EAS_FALSE)) != EAS_SUCCESS)
         return result;
-    if (wtemp != WAVE_FORMAT_PCM)
+    switch(wtemp)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Unsupported DLS sample format %04x\n", wtemp); */ }
-        return EAS_ERROR_UNRECOGNIZED_FORMAT;
+        case WAVE_FORMAT_PCM:
+        case WAVE_FORMAT_ALAW:
+        case WAVE_FORMAT_MULAW:
+            p->fmtTag = wtemp;
+            break;
+        default:
+            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Unsupported DLS sample format %04x\n", wtemp); */ }
+            return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
     /* get number of channels */
@@ -1267,6 +1277,9 @@ static EAS_RESULT Parse_data (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     EAS_I32 count;
     EAS_I32 i;
     EAS_I8 *p;
+
+    if (pWsmp->fmtTag != WAVE_FORMAT_PCM)
+        return EAS_ERROR_UNRECOGNIZED_FORMAT;
 
     /* seek to start of chunk */
     if ((result = EAS_HWFileSeek(pDLSData->hwInstData, pDLSData->fileHandle, pos)) != EAS_SUCCESS)
@@ -1358,9 +1371,26 @@ static EAS_RESULT Parse_data (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
         }
         else
         {
-            for(i=0; i<count; i++)
+            switch(pWsmp->fmtTag)
             {
-                *p++ = (short)((convBuf[i] ^ 0x80) << 8);
+                case WAVE_FORMAT_ALAW:
+                    for(i=0; i<count; i++)
+                    {
+                        *p++ = alaw2linear(convBuf[i]);
+                    }
+                    break;
+                case WAVE_FORMAT_MULAW:
+                    for(i=0; i<count; i++)
+                    {
+                        *p++ = ulaw2linear(convBuf[i]);
+                    break;
+                }
+                default:
+                    for(i=0; i<count; i++)
+                    {
+                        *p++ = (short)((convBuf[i] ^ 0x80) << 8);
+                    }
+                    break;
             }
         }
 

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -1383,9 +1383,9 @@ static EAS_RESULT Parse_data (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
                     for(i=0; i<count; i++)
                     {
                         *p++ = ulaw2linear(convBuf[i]);
+                    }
                     break;
-                }
-                default:
+                case WAVE_FORMAT_PCM:
                     for(i=0; i<count; i++)
                     {
                         *p++ = (short)((convBuf[i] ^ 0x80) << 8);

--- a/arm-wt-22k/lib_src/eas_mdls.h
+++ b/arm-wt-22k/lib_src/eas_mdls.h
@@ -243,6 +243,8 @@ This is useful for determining the DLS chunk types
 
 
 #define WAVE_FORMAT_PCM             0x0001 /* Microsoft PCM format, see DLS2.1 p60 */
+#define WAVE_FORMAT_ALAW            0x0006
+#define WAVE_FORMAT_MULAW           0x0007
 #define WAVE_FORMAT_EXTENSIBLE      0xffff
 
 /* defines for wave table structures */

--- a/arm-wt-22k/lib_src/eas_mdls.h
+++ b/arm-wt-22k/lib_src/eas_mdls.h
@@ -243,8 +243,8 @@ This is useful for determining the DLS chunk types
 
 
 #define WAVE_FORMAT_PCM             0x0001 /* Microsoft PCM format, see DLS2.1 p60 */
-#define WAVE_FORMAT_ALAW            0x0006
-#define WAVE_FORMAT_MULAW           0x0007
+#define WAVE_FORMAT_ALAW            0x0006 /* Defined same as Microsoft's mmreg.h */
+#define WAVE_FORMAT_MULAW           0x0007 /* Defined same as Microsoft's mmreg.h */
 #define WAVE_FORMAT_EXTENSIBLE      0xffff
 
 /* defines for wave table structures */

--- a/arm-wt-22k/lib_src/pcm_aulaw.h
+++ b/arm-wt-22k/lib_src/pcm_aulaw.h
@@ -1,0 +1,118 @@
+/*
+ * This source code is a product of Sun Microsystems, Inc. and is provided
+ * for unrestricted use.  Users may copy or modify this source code without
+ * charge.
+ *
+ * SUN SOURCE CODE IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING
+ * THE WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+ *
+ * Sun source code is provided with no support and without any obligation on
+ * the part of Sun Microsystems, Inc. to assist in its use, correction,
+ * modification or enhancement.
+ *
+ * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+ * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY THIS SOFTWARE
+ * OR ANY PART THEREOF.
+ *
+ * In no event will Sun Microsystems, Inc. be liable for any lost revenue
+ * or profits or other special, indirect and consequential damages, even if
+ * Sun has been advised of the possibility of such damages.
+ *
+ * Sun Microsystems, Inc.
+ * 2550 Garcia Avenue
+ * Mountain View, California  94043
+ */
+/*
+ * December 30, 1994:
+ * Functions linear2alaw, linear2ulaw have been updated to correctly
+ * convert unquantized 16 bit values.
+ * Tables for direct u- to A-law and A- to u-law conversions have been
+ * corrected.
+ * Borge Lindberg, Center for PersonKommunikation, Aalborg University.
+ * bli@cpk.auc.dk
+ *
+ */
+/*
+ * Downloaded from comp.speech site in Cambridge.
+ *
+ */
+
+/*
+ * pcm_aulaw.c
+ *
+ * u-law, A-law and linear PCM conversions.
+ * Source: http://www.speech.kth.se/cost250/refsys/latest/src/g711.c
+ */
+
+#ifndef _G711_H_
+#define _G711_H_
+
+#define	SIGN_BIT    (0x80)      /* Sign bit for a A-law byte. */
+#define	QUANT_MASK  (0xf)       /* Quantization field mask. */
+#define	SEG_SHIFT   (4)         /* Left shift for segment number. */
+#define	SEG_MASK    (0x70)      /* Segment field mask. */
+
+/*
+ * alaw2linear() - Convert an A-law value to 16-bit linear PCM
+ *
+ */
+static short
+alaw2linear(
+   unsigned char a_val)
+{
+   short t;
+   short seg;
+   
+   a_val ^= 0x55;
+   
+   t = (a_val & QUANT_MASK) << 4;
+   seg = ((unsigned)a_val & SEG_MASK) >> SEG_SHIFT;
+   switch (seg) {
+   case 0:
+      t += 8;
+      break;
+   case 1:
+      t += 0x108;
+      break;
+   default:
+      t += 0x108;
+      t <<= seg - 1;
+   }
+   return ((a_val & SIGN_BIT) ? t : -t);
+}
+
+#define	BIAS    (0x84)      /* Bias for linear code. */
+#define CLIP    8159
+
+/*
+ * ulaw2linear() - Convert a u-law value to 16-bit linear PCM
+ *
+ * First, a biased linear code is derived from the code word. An unbiased
+ * output can then be obtained by subtracting 33 from the biased code.
+ *
+ * Note that this function expects to be passed the complement of the
+ * original code word. This is in keeping with ISDN conventions.
+ */
+static short
+ulaw2linear(
+   unsigned char u_val)
+{
+   short t;
+   
+   /* Complement to obtain normal u-law value. */
+   u_val = ~u_val;
+   
+   /*
+    * Extract and bias the quantization bits. Then
+    * shift up by the segment number and subtract out the bias.
+    */
+   t = ((u_val & QUANT_MASK) << 3) + BIAS;
+   t <<= ((unsigned)u_val & SEG_MASK) >> SEG_SHIFT;
+   
+   return ((u_val & SIGN_BIT) ? (BIAS - t) : (t - BIAS));
+}
+
+#endif /* _G711_H_ */
+
+/* ---------- end of pcm_aulaw.c ----------------------------------------------------- */


### PR DESCRIPTION
## Description

Origin DLS soundfont loader can't load dls file with a-law/u-law wave format, I modified and make it work

## Related Issues

[Add a-law/u-law decoder for dls #38](https://github.com/pedrolcl/sonivox/issues/38)

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

