### PR TITLE
Fix logic error in loop boundary check

### DIFF
--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -1330,7 +1330,7 @@ static EAS_RESULT Parse_data (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     if (pWsmp->loopLength)
     {
         if (sampleLen < sizeof(EAS_SAMPLE)
-            || (pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen - sizeof(EAS_SAMPLE))
+            || (pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen)
         {
             return EAS_FAILURE;
         }
@@ -1404,7 +1404,8 @@ static EAS_RESULT Parse_data (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
             return EAS_SUCCESS;
         }
         if (sampleLen < sizeof(EAS_SAMPLE)
-            || (pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen - sizeof(EAS_SAMPLE)) {
+            || (pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen)
+        {
             return EAS_FAILURE;
         }
 
@@ -1896,7 +1897,7 @@ static EAS_RESULT Parse_rgn (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_I
         {
             EAS_U32 sampleLen = pDLSData->pDLS->pDLSSampleLen[waveIndex];
             if (sampleLen < sizeof(EAS_SAMPLE)
-                || (pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen - sizeof(EAS_SAMPLE))
+                || (pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen)
             {
                 return EAS_FAILURE;
             }


### PR DESCRIPTION
## Description

In `eas_mdls.c`, there exists some conditional check that may cause unintended behavior:

```c
(pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen - sizeof(EAS_SAMPLE)
```

When the following equality occurs:

```c
(pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) == sampleLen
```

It results in failed file loading for DLS sound banks (test case: [Saga_2_Soundfont___Midi.rar](https://musical-artifacts.com/artifacts/1836/Saga_2_Soundfont___Midi.rar)).

The correct approach should be as follows

```c
(pWsmp->loopStart + pWsmp->loopLength) * sizeof(EAS_SAMPLE) > sampleLen
```

## Related Issues

Potential Logic Error in Loop Boundary Check Causes DLS File Load Failure #41

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

