### PR TITLE
Addition fix of #37: fix SonivoxTestEnvironment getTmp()

### DIFF
--- a/test/SonivoxTestEnvironment.h
+++ b/test/SonivoxTestEnvironment.h
@@ -28,11 +28,16 @@ class SonivoxTestEnvironment : public::testing::Environment {
 	SonivoxTestEnvironment() : deleteOutput(true) { 
 		if (getenv("TEMP") != nullptr) {
             tmp = getenv("TEMP");
-            if (tmp.at(tmp.length() - 1) != '/') {
-                tmp.push_back('/');
-            }
-            snprintf(OUTPUT_FILE, sizeof(OUTPUT_FILE), "%s/output_midi.pcm", getenv("TEMP"));
+        } else if (getenv("XDG_RUNTIME_DIR") != nullptr) {
+            tmp = getenv("XDG_RUNTIME_DIR");
+        } else {
+            tmp = "/tmp/";
         }
+        if (tmp.at(tmp.length() - 1) != '/') {
+            tmp.push_back('/');
+        }
+        snprintf(OUTPUT_FILE, sizeof(OUTPUT_FILE), "%s/output_midi.pcm", getenv("XDG_RUNTIME_DIR"));
+
         if (getenv("TEST_RESOURCES") != nullptr) {
             res = getenv("TEST_RESOURCES");
         }

--- a/test/SonivoxTestEnvironment.h
+++ b/test/SonivoxTestEnvironment.h
@@ -36,7 +36,7 @@ class SonivoxTestEnvironment : public::testing::Environment {
         if (tmp.at(tmp.length() - 1) != '/') {
             tmp.push_back('/');
         }
-        snprintf(OUTPUT_FILE, sizeof(OUTPUT_FILE), "%s/output_midi.pcm", getenv("XDG_RUNTIME_DIR"));
+        snprintf(OUTPUT_FILE, sizeof(OUTPUT_FILE), "%soutput_midi.pcm", tmp.c_str());
 
         if (getenv("TEST_RESOURCES") != nullptr) {
             res = getenv("TEST_RESOURCES");


### PR DESCRIPTION
## Description

#37 added the usage of XDG_RUNTIME_DIR but kept SonivoxTestEnvironment unmodified. It causes failed tests when tempdir is acquired from XDG_RUNTIME_DIR env var.

This PR makes tempdir logic in tests the same as in CMake.

## Related Issues

Fixes #32

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

