### PR TITLE
Rescue commented logging calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ list(APPEND HEADERS
     arm-wt-22k/host_src/eas_chorus.h
     arm-wt-22k/host_src/eas_reverb.h
     arm-wt-22k/host_src/eas_types.h
+    arm-wt-22k/host_src/eas_report.h
 #arm-wt-22k/host_src/jet.h
 )
 

--- a/arm-wt-22k/host_src/eas_report.c
+++ b/arm-wt-22k/host_src/eas_report.c
@@ -44,8 +44,6 @@ static int severityLevel = 9999;
 static FILE *debugFile = NULL;
 int flush = 0;
 
-#ifndef _NO_DEBUG_PREPROCESSOR
-
 /* structure should have an #include for each error message header file */
 S_DEBUG_MESSAGES debugMessages[] =
 {
@@ -176,7 +174,6 @@ void EAS_ReportEx (int severity, unsigned long hashCode, int serialNum, ...)
     printf("Unrecognized error: Severity=%d; HashCode=%lu; SerialNum=%d\n", severity, hashCode, serialNum);
 } /* end EAS_ReportEx */
 
-#else
 /*----------------------------------------------------------------------------
  * EAS_Report()
  *
@@ -236,7 +233,6 @@ void EAS_ReportX (int severity, const char *fmt, ...)
     }
     va_end(vargs);
 } /* end EAS_ReportX */
-#endif
 
 /*----------------------------------------------------------------------------
  * EAS_SetDebugLevel()

--- a/arm-wt-22k/host_src/eas_report.h
+++ b/arm-wt-22k/host_src/eas_report.h
@@ -46,8 +46,6 @@
 extern "C" {
 #endif
 
-#ifndef _NO_DEBUG_PREPROCESSOR
-
 /* structure for included debug message header files */
 typedef struct
 {
@@ -59,13 +57,9 @@ typedef struct
 /* debug message handling prototypes */
 extern void EAS_ReportEx (int severity, unsigned long hashCode, int serialNum, ...);
 
-#else
-
 /* these prototypes are used if the debug preprocessor is not used */
 extern void EAS_Report (int severity, const char* fmt, ...);
 extern void EAS_ReportX (int severity, const char* fmt, ...);
-
-#endif
 
 extern void EAS_SetDebugLevel (int severity);
 extern void EAS_SetDebugFile (void *file, int flushAfterWrite);

--- a/arm-wt-22k/include/libsonivox/eas_report.h
+++ b/arm-wt-22k/include/libsonivox/eas_report.h
@@ -1,0 +1,1 @@
+../../host_src/eas_report.h

--- a/arm-wt-22k/lib_src/eas_dlssynth.c
+++ b/arm-wt-22k/lib_src/eas_dlssynth.c
@@ -584,7 +584,7 @@ static void DLS_UpdateEnvelope (S_SYNTH_VOICE *pVoice, S_SYNTH_CHANNEL *pChannel
             return;
 
         default:
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Envelope in invalid state %d\n", *pState); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Envelope in invalid state %d\n", *pState);
             break;
     }
 }

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -1128,7 +1128,7 @@ static EAS_RESULT Parse_wsmp (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WS
         return result;
     if (p->gain > 0)
     {
-        EAS_Report(_EAS_SEVERITY_WARNING, "Positive gain [%ld] in DLS wsmp ignored, set to 0dB\n", p->gain);
+        EAS_Report(_EAS_SEVERITY_DETAIL, "Positive gain [%ld] in DLS wsmp ignored, set to 0dB\n", p->gain);
         p->gain = 0;
     }
 

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -512,7 +512,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         return result;
     if (temp != CHUNK_DLS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Expected DLS chunk, got %08lx\n", temp); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Expected DLS chunk, got %08lx\n", temp);
         return EAS_ERROR_FILE_FORMAT;
     }
 
@@ -563,21 +563,21 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
     /* must have a lins chunk */
     if (linsSize == 0)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "No lins chunk found"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "No lins chunk found");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
     /* must have a wvpl chunk */
     if (wvplSize == 0)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "No wvpl chunk found"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "No wvpl chunk found");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
     /* must have a ptbl chunk */
     if ((ptblSize == 0) || (ptblSize > (EAS_I32) (DLS_MAX_WAVE_COUNT * sizeof(POOLCUE) + sizeof(POOLTABLE))))
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "No ptbl chunk found"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "No ptbl chunk found");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -588,7 +588,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
     /* limit check  */
     if ((dls.waveCount == 0) || (dls.waveCount > DLS_MAX_WAVE_COUNT))
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS file contains invalid #waves [%u]\n", dls.waveCount); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS file contains invalid #waves [%u]\n", dls.waveCount);
         return EAS_ERROR_FILE_FORMAT;
     }
 
@@ -596,7 +596,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
     dls.wsmpData = EAS_HWMalloc(dls.hwInstData, (EAS_I32) (sizeof(S_WSMP_DATA) * dls.waveCount));
     if (dls.wsmpData == NULL)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "EAS_HWMalloc for wsmp data failed\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "EAS_HWMalloc for wsmp data failed\n");
         return EAS_ERROR_MALLOC_FAILED;
     }
     EAS_HWMemSet(dls.wsmpData, 0, (EAS_I32) (sizeof(S_WSMP_DATA) * dls.waveCount));
@@ -609,7 +609,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         /* limit check  */
         if ((dls.regionCount == 0) || (dls.regionCount > DLS_MAX_REGION_COUNT))
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS file contains invalid #regions [%u]\n", dls.regionCount); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "DLS file contains invalid #regions [%u]\n", dls.regionCount);
             EAS_HWFree(dls.hwInstData, dls.wsmpData);
             return EAS_ERROR_FILE_FORMAT;
         }
@@ -617,7 +617,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         /* limit check  */
         if ((dls.artCount == 0) || (dls.artCount > DLS_MAX_ART_COUNT))
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS file contains invalid #articulations [%u]\n", dls.regionCount); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "DLS file contains invalid #articulations [%u]\n", dls.artCount);
             EAS_HWFree(dls.hwInstData, dls.wsmpData);
             return EAS_ERROR_FILE_FORMAT;
         }
@@ -625,7 +625,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         /* limit check  */
         if ((dls.instCount == 0) || (dls.instCount > DLS_MAX_INST_COUNT))
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS file contains invalid #instruments [%u]\n", dls.instCount); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "DLS file contains invalid #instruments [%u]\n", dls.instCount);
             EAS_HWFree(dls.hwInstData, dls.wsmpData);
             return EAS_ERROR_FILE_FORMAT;
         }
@@ -655,7 +655,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         dls.pDLS = EAS_HWMalloc(dls.hwInstData, size);
         if (dls.pDLS == NULL)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "EAS_HWMalloc failed for DLS memory allocation size %ld\n", size); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "EAS_HWMalloc failed for DLS memory allocation size %ld\n", size);
             EAS_HWFree(dls.hwInstData, dls.wsmpData);
             return EAS_ERROR_MALLOC_FAILED;
         }
@@ -799,6 +799,7 @@ static EAS_RESULT NextChunk (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 *pPos, EAS
         return result;
 
     if (*pSize < 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "Invalid DLS chunk size\n");
         ALOGE("b/37093318");
         return EAS_ERROR_FILE_FORMAT;
     }
@@ -884,7 +885,7 @@ static EAS_RESULT Parse_ptbl (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
             return result;
         if (temp > (EAS_U32) wtblSize)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Ptbl offset exceeds size of wtbl\n"); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Ptbl offset exceeds size of wtbl\n");
             EAS_HWCloseFile(pDLSData->hwInstData, tempFile);
             return EAS_ERROR_FILE_FORMAT;
         }
@@ -940,7 +941,7 @@ static EAS_RESULT Parse_wave (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     /* make sure it is a wave chunk */
     if (temp != CHUNK_WAVE)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Offset in ptbl does not point to wave chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Offset in ptbl does not point to wave chunk\n");
         return EAS_ERROR_FILE_FORMAT;
     }
 
@@ -998,14 +999,14 @@ static EAS_RESULT Parse_wave (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     /* must have a fmt chunk */
     if (!fmtPos)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS wave chunk has no fmt chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS wave chunk has no fmt chunk\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
     /* must have a data chunk */
     if (!dataPos)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS wave chunk has no data chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS wave chunk has no data chunk\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -1068,7 +1069,7 @@ static EAS_RESULT Parse_wave (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     pDLSData->wavePoolOffset += (EAS_U32) size;
     if (pDLSData->wavePoolOffset > pDLSData->wavePoolSize)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Wave pool exceeded allocation\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Wave pool exceeded allocation\n");
         return EAS_ERROR_SOUND_LIBRARY;
     }
 
@@ -1115,7 +1116,7 @@ static EAS_RESULT Parse_wsmp (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WS
     else
     {
         p->unityNote = 60;
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "Invalid unity note [%u] in DLS wsmp ignored, set to 60\n", wtemp); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "Invalid unity note [%u] in DLS wsmp ignored, set to 60\n", wtemp);
     }
 
     /* get fine tune */
@@ -1127,7 +1128,7 @@ static EAS_RESULT Parse_wsmp (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WS
         return result;
     if (p->gain > 0)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "Positive gain [%ld] in DLS wsmp ignored, set to 0dB\n", p->gain); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "Positive gain [%ld] in DLS wsmp ignored, set to 0dB\n", p->gain);
         p->gain = 0;
     }
 
@@ -1144,7 +1145,7 @@ static EAS_RESULT Parse_wsmp (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WS
     {
 
         if (ltemp > 1)
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS sample with %lu loops, ignoring extra loops\n", ltemp); */ }
+            EAS_Report(_EAS_SEVERITY_WARNING, "DLS sample with %lu loops, ignoring extra loops\n", ltemp);
 
         /* skip ahead to loop data */
         if ((result = EAS_HWFileSeek(pDLSData->hwInstData, pDLSData->fileHandle, pos + (EAS_I32) cbSize)) != EAS_SUCCESS)
@@ -1213,7 +1214,7 @@ static EAS_RESULT Parse_fmt (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WSM
             p->fmtTag = wtemp;
             break;
         default:
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Unsupported DLS sample format %04x\n", wtemp); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Unsupported DLS sample format %04x\n", wtemp);
             return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -1222,7 +1223,7 @@ static EAS_RESULT Parse_fmt (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WSM
         return result;
     if (wtemp != 1)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "No support for DLS multi-channel samples\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "No support for DLS multi-channel samples\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -1244,7 +1245,7 @@ static EAS_RESULT Parse_fmt (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WSM
 
     if ((p->bitsPerSample != 8) && (p->bitsPerSample != 16))
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Unsupported DLS bits-per-sample %d\n", p->bitsPerSample); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Unsupported DLS bits-per-sample %d\n", p->bitsPerSample);
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -1553,14 +1554,14 @@ static EAS_RESULT Parse_ins (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_I
     /* must have an lrgn to be useful */
     if (!lrgnPos)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS ins chunk has no lrgn chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS ins chunk has no lrgn chunk\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
     /* must have an insh to be useful */
     if (!inshPos)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS ins chunk has no insh chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS ins chunk has no insh chunk\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -1643,7 +1644,7 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     /* verify the parameters are valid */
     if (bank & 0x7fff8080)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08lx\n", bank); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08lx\n", bank);
     }
     if (bank & 0x80000000u)
     {
@@ -1658,7 +1659,7 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     }
     if (program > 127)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS program number is out of range: %08lx\n", program); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS program number is out of range: %08lx\n", program);
         program &= 0x7f;
     }
 
@@ -1708,7 +1709,7 @@ static EAS_RESULT Parse_lrgn (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
         {
             if (regionCount == numRegions)
             {
-                { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS region count exceeded cRegions value in insh, extra region ignored\n"); */ }
+                EAS_Report(_EAS_SEVERITY_WARNING, "DLS region count exceeded cRegions value in insh, extra region ignored\n");
                 return EAS_SUCCESS;
             }
             /* if second pass, ensure regionCount is less than numDLSRegions */
@@ -1825,14 +1826,14 @@ static EAS_RESULT Parse_rgn (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_I
     /* must have a rgnh chunk to be useful */
     if (!rgnhPos)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS rgn chunk has no rgnh chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS rgn chunk has no rgnh chunk\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
     /* must have a wlnk chunk to be useful */
     if (!wlnkPos)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "DLS rgn chunk has no wlnk chunk\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS rgn chunk has no wlnk chunk\n");
         return EAS_ERROR_UNRECOGNIZED_FORMAT;
     }
 
@@ -1950,12 +1951,12 @@ static EAS_RESULT Parse_rgnh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_DL
     /* check the range */
     if (lowKey > 127)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS rgnh: Low key out of range [%u]\n", lowKey); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS rgnh: Low key out of range [%u]\n", lowKey);
         lowKey = 127;
     }
     if (highKey > 127)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS rgnh: High key out of range [%u]\n", lowKey); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS rgnh: High key out of range [%u]\n", lowKey);
         highKey = 127;
     }
 
@@ -1968,12 +1969,12 @@ static EAS_RESULT Parse_rgnh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_DL
     /* check the range */
     if (lowVel > 127)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS rgnh: Low velocity out of range [%u]\n", lowVel); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS rgnh: Low velocity out of range [%u]\n", lowVel);
         lowVel = 127;
     }
     if (highVel > 127)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS rgnh: High velocity out of range [%u]\n", highVel); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS rgnh: High velocity out of range [%u]\n", highVel);
         highVel = 127;
     }
 
@@ -2152,7 +2153,7 @@ static EAS_RESULT Parse_art (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_DLS
             }
         }
         if (i == PARAM_TABLE_SIZE)
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "WARN: Unsupported parameter in DLS file\n"); */ }
+            EAS_Report(_EAS_SEVERITY_WARNING, "WARN: Unsupported parameter in DLS file\n");
     }
 
     return EAS_SUCCESS;
@@ -2230,6 +2231,7 @@ static EAS_RESULT PushcdlStack (EAS_U32 *pStack, EAS_INT *pStackPtr, EAS_U32 val
 
     /* stack overflow, return an error */
     if (*pStackPtr >= (CDL_STACK_SIZE - 1)) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "DLS cdl stack overflow\n");
         ALOGE("b/34031018, stackPtr(%d)", *pStackPtr);
         android_errorWriteLog(0x534e4554, "34031018");
         return EAS_ERROR_FILE_FORMAT;
@@ -2455,7 +2457,7 @@ static EAS_RESULT Parse_cdl (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 size, EAS_
             x = QueryGUID(&dlsid, &y);
         }
         else
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "Unsupported opcode %d in DLS file\n", opcode); */ }
+            EAS_Report(_EAS_SEVERITY_WARNING, "Unsupported opcode %d in DLS file\n", opcode);
 
         /* push the result on the stack */
         if ((result = PushcdlStack(stack, &stackPtr, x)) != EAS_SUCCESS)

--- a/arm-wt-22k/lib_src/eas_midi.c
+++ b/arm-wt-22k/lib_src/eas_midi.c
@@ -207,7 +207,7 @@ EAS_RESULT EAS_ParseMIDIStream (S_EAS_DATA *pEASData, S_SYNTH *pSynth, S_MIDI_ST
     }
 
     /* no status byte received, provide a warning, but we should be able to recover */
-    { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "Received MIDI data without a valid status byte: %d\n",c); */ }
+    EAS_Report(_EAS_SEVERITY_WARNING, "Received MIDI data without a valid status byte: %d\n",c);
     pMIDIStream->pending = EAS_FALSE;
     return EAS_SUCCESS;
 }

--- a/arm-wt-22k/lib_src/eas_public.c
+++ b/arm-wt-22k/lib_src/eas_public.c
@@ -211,7 +211,7 @@ EAS_RESULT EAS_IntSetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_IN
             break;
 
         default:
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Invalid paramter %d in call to EAS_IntSetStrmParam", param); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Invalid paramter %d in call to EAS_IntSetStrmParam", param);
             return EAS_ERROR_INVALID_PARAMETER;
     }
 
@@ -260,7 +260,7 @@ EAS_RESULT EAS_IntGetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_IN
             break;
 
         default:
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Invalid paramter %d in call to EAS_IntSetStrmParam", param); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Invalid paramter %d in call to EAS_IntSetStrmParam", param);
             return EAS_ERROR_INVALID_PARAMETER;
     }
 
@@ -288,7 +288,7 @@ static EAS_INT EAS_AllocateStream (EAS_DATA_HANDLE pEASData)
     {
         if (pEASData->streams[0].handle != NULL)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Attempt to open multiple streams in static model\n"); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Attempt to open multiple streams in static model\n");
             return -1;
         }
         return 0;
@@ -300,7 +300,7 @@ static EAS_INT EAS_AllocateStream (EAS_DATA_HANDLE pEASData)
             break;
     if (streamNum == MAX_NUMBER_STREAMS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Exceeded maximum number of open streams\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Exceeded maximum number of open streams\n");
         return -1;
     }
     return streamNum;
@@ -383,7 +383,7 @@ EAS_PUBLIC EAS_RESULT EAS_Init (EAS_DATA_HANDLE *ppEASData)
         pEASData = EAS_HWMalloc(pHWInstData, sizeof(S_EAS_DATA));
     if (!pEASData)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_FATAL, "Failed to allocate EAS library memory\n"); */ }
+        EAS_Report(_EAS_SEVERITY_FATAL, "Failed to allocate EAS library memory\n");
         return EAS_ERROR_MALLOC_FAILED;
     }
 
@@ -408,7 +408,7 @@ EAS_PUBLIC EAS_RESULT EAS_Init (EAS_DATA_HANDLE *ppEASData)
     {
         if ((result = (*pEASData->pMetricsModule->pfInit)(pEASData, &pEASData->pMetricsData)) != EAS_SUCCESS)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld initializing metrics module\n", result); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld initializing metrics module\n", result);
             return result;
         }
     }
@@ -421,7 +421,7 @@ EAS_PUBLIC EAS_RESULT EAS_Init (EAS_DATA_HANDLE *ppEASData)
     /* initialize mix engine */
     if ((result = EAS_MixEngineInit(pEASData)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld starting up mix engine\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld starting up mix engine\n", result);
         return result;
     }
 
@@ -433,7 +433,7 @@ EAS_PUBLIC EAS_RESULT EAS_Init (EAS_DATA_HANDLE *ppEASData)
         {
             if ((result = (*pEASData->effectsModules[module].effect->pfInit)(pEASData, &pEASData->effectsModules[module].effectData)) != EAS_SUCCESS)
             {
-                { /* dpp: EAS_ReportEx(_EAS_SEVERITY_FATAL, "Initialization of effects module %d returned %d\n", module, result); */ }
+                EAS_Report(_EAS_SEVERITY_FATAL, "Initialization of effects module %d returned %d\n", module, result);
                 return result;
             }
         }
@@ -442,7 +442,7 @@ EAS_PUBLIC EAS_RESULT EAS_Init (EAS_DATA_HANDLE *ppEASData)
     /* initialize PCM engine */
     if ((result = EAS_PEInit(pEASData)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_FATAL, "EAS_PEInit failed with error code %ld\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_FATAL, "EAS_PEInit failed with error code %ld\n", result);
         return result;
     }
 
@@ -486,7 +486,7 @@ EAS_PUBLIC EAS_RESULT EAS_Shutdown (EAS_DATA_HANDLE pEASData)
         {
             if ((result = (*((S_FILE_PARSER_INTERFACE*)(pEASData->streams[i].pParserModule))->pfClose)(pEASData, pEASData->streams[i].handle)) != EAS_SUCCESS)
             {
-                { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld shutting down parser module\n", result); */ }
+                EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld shutting down parser module\n", result);
                 reportResult = result;
             }
         }
@@ -495,7 +495,7 @@ EAS_PUBLIC EAS_RESULT EAS_Shutdown (EAS_DATA_HANDLE pEASData)
     /* shutdown PCM engine */
     if ((result = EAS_PEShutdown(pEASData)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld shutting down PCM engine\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld shutting down PCM engine\n", result);
         if (reportResult == EAS_SUCCESS)
             reportResult = result;
     }
@@ -503,7 +503,7 @@ EAS_PUBLIC EAS_RESULT EAS_Shutdown (EAS_DATA_HANDLE pEASData)
     /* shutdown mix engine */
     if ((result = EAS_MixEngineShutdown(pEASData)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld shutting down mix engine\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld shutting down mix engine\n", result);
         if (reportResult == EAS_SUCCESS)
             reportResult = result;
     }
@@ -515,7 +515,7 @@ EAS_PUBLIC EAS_RESULT EAS_Shutdown (EAS_DATA_HANDLE pEASData)
         {
             if ((result = (*pEASData->effectsModules[i].effect->pfShutdown)(pEASData, pEASData->effectsModules[i].effectData)) != EAS_SUCCESS)
             {
-                { /* dpp: EAS_ReportEx(_EAS_SEVERITY_FATAL, "Shutdown of effects module %d returned %d\n", i, result); */ }
+                EAS_Report(_EAS_SEVERITY_FATAL, "Shutdown of effects module %d returned %d\n", i, result);
                 if (reportResult == EAS_SUCCESS)
                     reportResult = result;
             }
@@ -531,7 +531,7 @@ EAS_PUBLIC EAS_RESULT EAS_Shutdown (EAS_DATA_HANDLE pEASData)
     {
         if ((result = (*pEASData->pMetricsModule->pfShutdown)(pEASData, pEASData->pMetricsData)) != EAS_SUCCESS)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld shutting down metrics module\n", result); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld shutting down metrics module\n", result);
             if (reportResult == EAS_SUCCESS)
                 reportResult = result;
         }
@@ -547,7 +547,7 @@ EAS_PUBLIC EAS_RESULT EAS_Shutdown (EAS_DATA_HANDLE pEASData)
     {
         if ((result = EAS_HWShutdown(hwInstData)) != EAS_SUCCESS)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Error %ld shutting down host wrappers\n", result); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Error %ld shutting down host wrappers\n", result);
             if (reportResult == EAS_SUCCESS)
                 reportResult = result;
         }
@@ -584,7 +584,7 @@ EAS_RESULT EAS_OpenJETStream (EAS_DATA_HANDLE pEASData, EAS_FILE_HANDLE fileHand
     /* see if SMF parser recognizes the file */
     if ((result = (*pParserModule->pfCheckFileType)(pEASData, fileHandle, &streamHandle, offset)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "CheckFileType returned error %ld\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "CheckFileType returned error %ld\n", result);
         return result;
     }
 
@@ -653,7 +653,7 @@ EAS_PUBLIC EAS_RESULT EAS_OpenFile (EAS_DATA_HANDLE pEASData, EAS_FILE_LOCATOR l
             /* Closing the opened file as file type check failed */
             EAS_HWCloseFile(pEASData->hwInstData, fileHandle);
 
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "CheckFileType returned error %ld\n", result); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "CheckFileType returned error %ld\n", result);
             return result;
         }
 
@@ -674,12 +674,12 @@ EAS_PUBLIC EAS_RESULT EAS_OpenFile (EAS_DATA_HANDLE pEASData, EAS_FILE_LOCATOR l
             EAS_HWCloseFile(pEASData->hwInstData, fileHandle);
 
             return result;
-         }
+        }
     }
 
     /* no parser was able to recognize the file, close it and return an error */
     EAS_HWCloseFile(pEASData->hwInstData, fileHandle);
-    { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "No parser recognized the requested file\n"); */ }
+    EAS_Report(_EAS_SEVERITY_WARNING, "No parser recognized the requested file\n");
     return EAS_ERROR_UNRECOGNIZED_FORMAT;
 }
 
@@ -715,7 +715,7 @@ EAS_PUBLIC EAS_RESULT EAS_MMAPIToneControl (EAS_DATA_HANDLE pEASData, EAS_FILE_L
     pParserModule = EAS_CMEnumOptModules(EAS_MODULE_MMAPI_TONE_CONTROL);
     if (pParserModule == NULL)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "EAS_MMAPIToneControl: ToneControl parser not available\n"); */ }
+        /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "EAS_MMAPIToneControl: ToneControl parser not available\n"); */
         return EAS_ERROR_FEATURE_NOT_AVAILABLE;
     }
 
@@ -730,7 +730,7 @@ EAS_PUBLIC EAS_RESULT EAS_MMAPIToneControl (EAS_DATA_HANDLE pEASData, EAS_FILE_L
     /* see if ToneControl parser recognizes it */
     if ((result = (*pParserModule->pfCheckFileType)(pEASData, fileHandle, &streamHandle, 0L)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "CheckFileType returned error %ld\n", result); */ }
+        EAS_ReportEx(_EAS_SEVERITY_ERROR, "CheckFileType returned error %ld\n", result);
         return result;
     }
 
@@ -746,7 +746,7 @@ EAS_PUBLIC EAS_RESULT EAS_MMAPIToneControl (EAS_DATA_HANDLE pEASData, EAS_FILE_L
 
     /* parser did not recognize the file, close it and return an error */
     EAS_HWCloseFile(pEASData->hwInstData, fileHandle);
-    { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "No parser recognized the requested file\n"); */ }
+    EAS_ReportEx(_EAS_SEVERITY_WARNING, "No parser recognized the requested file\n");
     return EAS_ERROR_UNRECOGNIZED_FORMAT;
 }
 
@@ -871,8 +871,8 @@ EAS_PUBLIC EAS_RESULT EAS_Render (EAS_DATA_HANDLE pEASData, EAS_PCM *pOut, EAS_I
     /* no support for other buffer sizes yet */
     if (numRequested != BUFFER_SIZE_IN_MONO_SAMPLES)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "This library supports only %ld samples in buffer, host requested %ld samples\n",
-            (EAS_I32) BUFFER_SIZE_IN_MONO_SAMPLES, numRequested); */ }
+        { EAS_Report(_EAS_SEVERITY_ERROR, "This library supports only %ld samples in buffer, host requested %ld samples\n",
+            (EAS_I32) BUFFER_SIZE_IN_MONO_SAMPLES, numRequested); }
         return EAS_BUFFER_SIZE_MISMATCH;
     }
 
@@ -997,7 +997,7 @@ EAS_PUBLIC EAS_RESULT EAS_Render (EAS_DATA_HANDLE pEASData, EAS_PCM *pOut, EAS_I
     /* render audio */
     if ((result = VMRender(pEASData->pVoiceMgr, BUFFER_SIZE_IN_MONO_SAMPLES, pEASData->pMixBuffer, &voicesRendered)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "pfRender function returned error %ld\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "pfRender function returned error %ld\n", result);
         return result;
     }
 
@@ -1026,7 +1026,7 @@ EAS_PUBLIC EAS_RESULT EAS_Render (EAS_DATA_HANDLE pEASData, EAS_PCM *pOut, EAS_I
     /* render PCM audio */
     if ((result = EAS_PERender(pEASData, numRequested)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "EAS_PERender returned error %ld\n", result); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "EAS_PERender returned error %ld\n", result);
         return result;
     }
 
@@ -1309,6 +1309,7 @@ static EAS_RESULT EAS_ParseEvents (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS
                 if (pParserModule->pfEvent) {
                     if ((result = (*pParserModule->pfEvent)(pEASData, pStream->handle, parseMode))
                             != EAS_SUCCESS) {
+                        EAS_Report(_EAS_SEVERITY_ERROR, "%s() pfEvent returned %ld\n", __func__, result);
                         ALOGE("%s() pfEvent returned %ld", __func__, result);
                         return result;
                     }
@@ -1320,6 +1321,8 @@ static EAS_RESULT EAS_ParseEvents (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS
                 // when scanning the entire file in a single call to this function.
                 // OTA files will only do infinite loops when in eParserModePlay.
                 if (++eventCount >= MAX_EVENT_COUNT && parseMode == eParserModePlay) {
+                    EAS_Report(_EAS_SEVERITY_ERROR, "%s() reached events limit, aborting, %d events. Infinite loop in song file?!\n",
+                            __func__, eventCount);
                     ALOGE("%s() aborting, %d events. Infinite loop in song file?!",
                             __func__, eventCount);
                     android_errorWriteLog(0x534e4554, "68664359");
@@ -1547,7 +1550,7 @@ EAS_PUBLIC EAS_RESULT EAS_OpenMIDIStream (EAS_DATA_HANDLE pEASData, EAS_HANDLE *
     /* allocate dynamic memory */
     if (!pMIDIStream)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_FATAL, "Failed to allocate MIDI stream data\n"); */ }
+        EAS_Report(_EAS_SEVERITY_FATAL, "Failed to allocate MIDI stream data\n");
         return EAS_ERROR_MALLOC_FAILED;
     }
 

--- a/arm-wt-22k/lib_src/eas_smf.c
+++ b/arm-wt-22k/lib_src/eas_smf.c
@@ -845,6 +845,7 @@ static EAS_RESULT SMF_ParseMetaEvent (S_EAS_DATA *pEASData, S_SMF_DATA *pSMFData
     /* prevent a large unsigned length from being treated as a negative length */
     if ((EAS_I32) len < 0) {
         /* note that EAS_I32 is a long, which can be 64-bits on some computers */
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s() negative len = %ld\n", __func__, (long) len);
         ALOGE("%s() negative len = %ld", __func__, (long) len);
         android_errorWriteLog(0x534e4554, "68953854");
         return EAS_ERROR_FILE_FORMAT;
@@ -852,6 +853,7 @@ static EAS_RESULT SMF_ParseMetaEvent (S_EAS_DATA *pEASData, S_SMF_DATA *pSMFData
     /* prevent numeric overflow caused by a very large len, assume pos > 0 */
     const EAS_I32 EAS_I32_MAX = 0x7FFFFFFF;
     if ((EAS_I32) len > (EAS_I32_MAX - pos)) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s() too large len = %ld\n", __func__, (long) len);
         ALOGE("%s() too large len = %ld", __func__, (long) len);
         android_errorWriteLog(0x534e4554, "68953854");
         return EAS_ERROR_FILE_FORMAT;

--- a/arm-wt-22k/lib_src/eas_wtengine.c
+++ b/arm-wt-22k/lib_src/eas_wtengine.c
@@ -32,6 +32,7 @@
  * includes
  *------------------------------------
 */
+#include "eas_report.h"
 #include "log/log.h"
 #include <cutils/log.h>
 
@@ -96,10 +97,12 @@ void WT_VoiceGain (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
     /* initialize some local variables */
     numSamples = pWTIntFrame->numSamples;
     if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
@@ -197,10 +200,12 @@ void WT_Interpolate (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
     /* initialize some local variables */
     numSamples = pWTIntFrame->numSamples;
     if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
@@ -302,10 +307,12 @@ void WT_InterpolateNoLoop (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
     /* initialize some local variables */
     numSamples = pWTIntFrame->numSamples;
     if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
@@ -406,10 +413,12 @@ void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
     /* initialize some local variables */
     numSamples = pWTIntFrame->numSamples;
     if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
@@ -478,10 +487,12 @@ void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
     /* initialize some local variables */
     numSamples = pWTIntFrame->numSamples;
     if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
@@ -630,10 +641,12 @@ void WT_InterpolateMono (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
 
     numSamples = pWTIntFrame->numSamples;
     if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
         ALOGE("b/26366256");
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;

--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -494,10 +494,12 @@ EAS_BOOL WT_CheckSampleEnd (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame, E
             pWTIntFrame->numSamples = numSamples;
         }
         if (pWTIntFrame->numSamples < 0) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
             ALOGE("b/26366256");
             android_errorWriteLog(0x534e4554, "26366256");
             pWTIntFrame->numSamples = 0;
         } else if (pWTIntFrame->numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, pWTIntFrame->numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
             ALOGE("b/317780080 clip numSamples %ld -> %d",
                   pWTIntFrame->numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
             android_errorWriteLog(0x534e4554, "317780080");

--- a/arm-wt-22k/lib_src/eas_xmf.c
+++ b/arm-wt-22k/lib_src/eas_xmf.c
@@ -185,7 +185,7 @@ static EAS_RESULT XMF_CheckFileType (S_EAS_DATA *pEASData, EAS_FILE_HANDLE fileH
     /* locate the SMF and DLS contents */
     if ((result = XMF_FindFileContents(pEASData->hwInstData, pXMFData)) != EAS_SUCCESS)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "No SMF data found in XMF file\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "No SMF data found in XMF file\n");
         EAS_HWFree(pEASData->hwInstData, pXMFData);
         return result;
     }
@@ -232,7 +232,7 @@ static EAS_RESULT XMF_Prepare (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
     {
         if ((result = DLSParser(pEASData->hwInstData, pXMFData->fileHandle, pXMFData->dlsOffset, &pXMFData->pDLS)) != EAS_SUCCESS)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "Error converting XMF DLS data\n"); */ }
+            EAS_Report(_EAS_SEVERITY_WARNING, "Error converting XMF DLS data: %ld\n", result);
             return result;
         }
     }
@@ -572,13 +572,13 @@ static EAS_RESULT XMF_FindFileContents (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DAT
     /* check for SMF data */
     if (pXMFData->midiOffset == 0)
     {
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "No SMF data found in XMF file\n"); */ }
+        EAS_Report(_EAS_SEVERITY_ERROR, "No SMF data found in XMF file\n");
         return EAS_ERROR_FILE_FORMAT;
     }
 
     /* check for SFM in wrong order */
     if ((pXMFData->dlsOffset > 0) && (pXMFData->midiOffset < pXMFData->dlsOffset))
-        { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS data must precede SMF data in Mobile XMF file\n"); */ }
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS data must precede SMF data in Mobile XMF file\n");
 
     return EAS_SUCCESS;
 }
@@ -690,7 +690,7 @@ static EAS_RESULT XMF_ReadNode (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFD
         /* or else it must be an inline resource */
         else if (refType != 1)
         {
-            { /* dpp: EAS_ReportEx(_EAS_SEVERITY_ERROR, "Unexpected reference type %d\n", refType); */ }
+            EAS_Report(_EAS_SEVERITY_ERROR, "Unexpected reference type %d\n", refType);
             return EAS_ERROR_FILE_FORMAT;
         }
 

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -26,6 +26,7 @@
 #include <eas.h>
 #include <eas_reverb.h>
 #include <eas_chorus.h>
+#include <eas_report.h>
 
 const char *dls_path = NULL;
 EAS_I32 playback_gain = 90;
@@ -92,6 +93,9 @@ int initializeLibrary(void)
 #ifdef __WIN32__
 	setmode(fileno(stdout), O_BINARY);
 #endif
+
+    EAS_SetDebugFile(stderr, 1);
+    EAS_SetDebugLevel(_EAS_SEVERITY_WARNING);
 
     EAS_RESULT result = EAS_Init(&mEASDataHandle);
     if (result != EAS_SUCCESS) {

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -95,7 +95,11 @@ int initializeLibrary(void)
 #endif
 
     EAS_SetDebugFile(stderr, 1);
+#ifdef NDEBUG
     EAS_SetDebugLevel(_EAS_SEVERITY_WARNING);
+#else
+    EAS_SetDebugLevel(_EAS_SEVERITY_INFO);
+#endif
 
     EAS_RESULT result = EAS_Init(&mEASDataHandle);
     if (result != EAS_SUCCESS) {

--- a/test/SonivoxTest.cpp
+++ b/test/SonivoxTest.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 
 #include <libsonivox/eas.h>
+#include <libsonivox/eas_report.h>
 #include <libsonivox/eas_reverb.h>
 
 #include "SonivoxTestEnvironment.h"
@@ -419,8 +420,12 @@ int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     int status = gEnv->initFromOptions(argc, argv);
     if (status == 0) {
+        // Initalize EAS logging
+        EAS_SetDebugFile(stderr, 1);
+        EAS_SetDebugLevel(_EAS_SEVERITY_DETAIL); // print all messages
         status = RUN_ALL_TESTS();
         ALOGV("Test result = %d\n", status);
+        EAS_Report(_EAS_SEVERITY_INFO, "Test result = %d\n", status);
     }
     return status;
 }


### PR DESCRIPTION
## Description

Rescue commented logging calls, and also added loggings for AOSP's sanity checks.

Now sonivoxrender prints logs to stderr.

## Related Issues

Closes #43

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

