### PR TITLE
add arm64 job to Linux CI workflow

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -14,8 +14,14 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Linux CI
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: "x64", os: "ubuntu-24.04" }
+          - { arch: "arm64", os: "ubuntu-24.04-arm" }
+    runs-on: ${{ matrix.os }}
+    name: Linux CI ${{ matrix.arch }}
 
     steps:
     - uses: actions/checkout@v4
@@ -48,7 +54,7 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: SonivoxV3-linux
+        name: SonivoxV3-Linux-${{matrix.arch}}
         path: SonivoxV3.tar
         retention-days: 90
         overwrite: true


### PR DESCRIPTION
## Description

Add Arm64 architecture job to the Linux CI workflow

## Related Issues

Close #53 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

