### PR TITLE
Fix build with 8 bit samples

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         USE_44KHZ: [ON, OFF]
         USE_16BITS_SAMPLES: [ON, OFF]
+        arch: ["x64", "arm64"]
         include:
           - { icon: '🟥', arch: "x64", os: "ubuntu-24.04" }
           - { icon: '🟩', arch: "arm64", os: "ubuntu-24.04-arm" }

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        USE_44KHZ: [ON, OFF]
+        USE_16BITS_SAMPLES: [ON, OFF]
         include:
           - { icon: '🟥', arch: "x64", os: "ubuntu-24.04" }
           - { icon: '🟩', arch: "arm64", os: "ubuntu-24.04-arm" }
@@ -33,8 +35,8 @@ jobs:
       run: |
         mkdir -p ${{github.workspace}}/temp
 
-    - name: '${{ matrix.icon }} Configure CMake'
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}}
+    - name: '${{ matrix.icon }} Configure CMake with USE_44KHZ = ${{ matrix.USE_44KHZ }} and USE_16BITS_SAMPLES = ${{ matrix.USE_16BITS_SAMPLES }}'
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}} -DUSE_44KHZ=${{ matrix.USE_44KHZ }} -DUSE_16BITS_SAMPLES=${{ matrix.USE_16BITS_SAMPLES }}
 
     - name: '${{ matrix.icon }} Build'
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
## Description

Support for MP3 format decoding is only available when building with USE_16BITS_SAMPLES=ON.

## Related Issues

Fix #63 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

