### PR TITLE
implement soundfont cache

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   BUILD_TYPE: Release
-  TEMP: ${{github.workspace}}/temp/
+  TEMP: ${{github.workspace}}/temp
 
 jobs:
   build:
@@ -20,16 +20,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Temp Environment Variable
-      run: |
-        mkdir -p ${{github.workspace}}/temp
-
-    - name: Restore DLS Cache
-      uses: actions/cache/restore@v4
-      id: cache
-      with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
-        enableCrossOsArchive: true
+      run: mkdir temp
 
     - name: Configure CMake
       run: |
@@ -42,14 +33,6 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
             -DANDROID_ABI=x86_64 \
             -DANDROID_PLATFORM=android-35
-
-    - name: Store DLS Cache
-      if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
-        enableCrossOsArchive: true
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   BUILD_TYPE: Release
+  TEMP: ${{github.workspace}}/temp/
 
 jobs:
   build:
@@ -22,7 +23,7 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 
@@ -42,7 +43,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Restore DLS Cache
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
+
     - name: Configure CMake
       run: |
         cmake -B ${{github.workspace}}/build \
@@ -29,6 +37,14 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
             -DANDROID_ABI=x86_64 \
             -DANDROID_PLATFORM=android-35
+
+    - name: Store DLS Cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Temp Environment Variable
+      run: |
+        mkdir -p ${{github.workspace}}/temp
+
     - name: Restore DLS Cache
       uses: actions/cache/restore@v4
       id: cache

--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 
@@ -56,7 +56,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 

--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -26,8 +26,8 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: FreeBSD test
@@ -56,8 +56,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -15,11 +15,21 @@ jobs:
       BUILD_TYPE: RelWithDebInfo
       INSTALL_LOCATION: ${{github.workspace}}/SonivoxV3
       TEMP: ${{github.workspace}}/temp/
+
     steps:
     - uses: actions/checkout@v4
     - name: Temp Environment Variable
       run: |
         mkdir -p ${{github.workspace}}/temp
+
+    - name: Restore DLS Cache
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
+
     - name: FreeBSD test
       id: test
       uses: vmactions/freebsd-vm@v1
@@ -41,6 +51,14 @@ jobs:
           cd ${{github.workspace}}
           cmake --install ${{github.workspace}}/build
           tar cvf SonivoxV3.tar SonivoxV3
+
+    - name: Store DLS Cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -44,8 +44,8 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Configure CMake with USE_44KHZ=${{ matrix.USE_44KHZ }} and USE_16BITS_SAMPLES=${{ matrix.USE_16BITS_SAMPLES }}'
@@ -55,8 +55,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 
@@ -55,7 +55,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -40,8 +40,24 @@ jobs:
       run: |
         mkdir -p ${{github.workspace}}/temp
 
+    - name: '${{ matrix.icon }} Restore DLS Cache'
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
+
     - name: '${{ matrix.icon }} Configure CMake with USE_44KHZ=${{ matrix.USE_44KHZ }} and USE_16BITS_SAMPLES=${{ matrix.USE_16BITS_SAMPLES }}'
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}} -DUSE_44KHZ=${{ matrix.USE_44KHZ }} -DUSE_16BITS_SAMPLES=${{ matrix.USE_16BITS_SAMPLES }}
+
+    - name: '${{ matrix.icon }} Store DLS Cache'
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -24,8 +24,24 @@ jobs:
       run: |
         mkdir -p ${{github.workspace}}/temp
 
+    - name: Restore DLS Cache
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}}
+
+    - name: Store DLS Cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -28,8 +28,8 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: Configure CMake
@@ -39,8 +39,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: Build

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 
@@ -39,7 +39,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 

--- a/.github/workflows/win-msvc.yml
+++ b/.github/workflows/win-msvc.yml
@@ -10,6 +10,7 @@ on:
 env:
   BUILD_TYPE: RelWithDebInfo
   INSTALL_LOCATION: ${{github.workspace}}/SonivoxV3
+  TEMP: ${{github.workspace}}/temp/
 
 jobs:
   build:
@@ -30,8 +31,24 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
 
+    - name: '${{ matrix.icon }} Restore DLS Cache'
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
+
     - name: '${{ matrix.icon }} Configure CMake'
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}} -G Ninja
+
+    - name: '${{ matrix.icon }} Store DLS Cache'
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/win-msvc.yml
+++ b/.github/workflows/win-msvc.yml
@@ -31,12 +31,15 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
 
+    - name: '${{ matrix.icon }} Temp Environment Variable'
+      run: mkdir temp
+
     - name: '${{ matrix.icon }} Restore DLS Cache'
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Configure CMake'
@@ -46,8 +49,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'

--- a/.github/workflows/win-msvc.yml
+++ b/.github/workflows/win-msvc.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 
@@ -46,7 +46,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 

--- a/.github/workflows/win-msys2.yml
+++ b/.github/workflows/win-msys2.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 
@@ -61,7 +61,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: soundfont.dls
+        key: ${{ runner.os }}-soundfont.dls
         path: ${{env.TEMP}}
         enableCrossOsArchive: true
 

--- a/.github/workflows/win-msys2.yml
+++ b/.github/workflows/win-msys2.yml
@@ -46,12 +46,15 @@ jobs:
           ninja:p
           gtest:p
 
+    - name: '${{ matrix.icon }} Temp Environment Variable'
+      run: mkdir temp
+
     - name: '${{ matrix.icon }} Restore DLS Cache'
       uses: actions/cache/restore@v4
       id: cache
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Configure CMake'
@@ -61,8 +64,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: ${{ runner.os }}-soundfont.dls
-        path: ${{env.TEMP}}
+        key: soundfont.dls
+        path: temp
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'

--- a/.github/workflows/win-msys2.yml
+++ b/.github/workflows/win-msys2.yml
@@ -10,6 +10,7 @@ on:
 env:
   BUILD_TYPE: RelWithDebInfo
   INSTALL_LOCATION: SonivoxV3
+  TEMP: ${{github.workspace}}/temp/
 
 jobs:
   build:
@@ -45,8 +46,24 @@ jobs:
           ninja:p
           gtest:p
 
+    - name: '${{ matrix.icon }} Restore DLS Cache'
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
+
     - name: '${{ matrix.icon }} Configure CMake'
       run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}} -G Ninja
+
+    - name: '${{ matrix.icon }} Store DLS Cache'
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: soundfont.dls
+        path: ${{env.TEMP}}
+        enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'
       run: cmake --build build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
## Description

Implement cache for the test DLS file using actions/cache/save and actions/cache/restore.

The file is  downloaded by cmake, and [cross os cache](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache) is enabled.

## Related Issues

Fix: #70 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

