### PR TITLE
Fix #75: the ci cache fails for windows msys2 workflows

### DIFF
--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -27,7 +27,7 @@ jobs:
       id: cache
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: FreeBSD test
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -45,7 +45,7 @@ jobs:
       id: cache
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Configure CMake with USE_44KHZ=${{ matrix.USE_44KHZ }} and USE_16BITS_SAMPLES=${{ matrix.USE_16BITS_SAMPLES }}'
@@ -56,7 +56,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -29,7 +29,7 @@ jobs:
       id: cache
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: Configure CMake
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: Build

--- a/.github/workflows/win-msvc.yml
+++ b/.github/workflows/win-msvc.yml
@@ -39,7 +39,7 @@ jobs:
       id: cache
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Configure CMake'
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'

--- a/.github/workflows/win-msys2.yml
+++ b/.github/workflows/win-msys2.yml
@@ -10,7 +10,6 @@ on:
 env:
   BUILD_TYPE: RelWithDebInfo
   INSTALL_LOCATION: SonivoxV3
-  TEMP: ${{github.workspace}}/temp/
 
 jobs:
   build:
@@ -46,7 +45,7 @@ jobs:
           ninja:p
           gtest:p
 
-    - name: '${{ matrix.icon }} Temp Environment Variable'
+    - name: '${{ matrix.icon }} Temp Directory'
       run: mkdir temp
 
     - name: '${{ matrix.icon }} Restore DLS Cache'
@@ -54,18 +53,26 @@ jobs:
       id: cache
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
+
+    - name: '${{ matrix.icon }} Copy soundfont to TEMP'
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: cp temp/soundfont.dls $TEMP
 
     - name: '${{ matrix.icon }} Configure CMake'
       run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}} -G Ninja
+
+    - name: '${{ matrix.icon }} Copy from TEMP'
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: cp $TEMP/soundfont.dls temp/soundfont.dls
 
     - name: '${{ matrix.icon }} Store DLS Cache'
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         key: soundfont.dls
-        path: temp
+        path: temp/soundfont.dls
         enableCrossOsArchive: true
 
     - name: '${{ matrix.icon }} Build'


### PR DESCRIPTION
## Description

MSYS2 workflows restore the DLS file from the cache, but cmake downloads another copy anyway. This is caused by the $TEMP directory that cannot be changed in MSYS2, so we need to copy the DLS around. Shame!

The extra DLS cache is created by the native windows worflow, arm64 job. I've found no solution for this.

## Related Issues

Fix #75 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.
