### PR TITLE
Add format warnings to EAS_Report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ target_include_directories( sonivox-objects PRIVATE
     fakes
 )
 
-if (CMAKE_COMPILER_IS_GNUCC)
+if (CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
     target_compile_options( sonivox-objects PRIVATE
         -Wno-unused-parameter
         -Wno-unused-value
@@ -209,6 +209,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
         -Wno-unused-function
         -Wno-misleading-indentation
         -Wno-attributes
+        -Wformat
     )
 endif()
 

--- a/arm-wt-22k/host_src/eas_report.h
+++ b/arm-wt-22k/host_src/eas_report.h
@@ -58,6 +58,9 @@ typedef struct
 extern void EAS_ReportEx (int severity, unsigned long hashCode, int serialNum, ...);
 
 /* these prototypes are used if the debug preprocessor is not used */
+#if defined (__GNUC__) || defined (__clang__)
+__attribute__((format(printf, 2, 3)))
+#endif
 extern void EAS_Report (int severity, const char* fmt, ...);
 extern void EAS_ReportX (int severity, const char* fmt, ...);
 

--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -471,13 +471,13 @@ EAS_BOOL WT_CheckSampleEnd (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame, E
         /*lint -e{703} use shift for performance */
         numSamples = (numSamples << NUM_PHASE_FRAC_BITS) - (EAS_I32) pWTVoice->phaseFrac;
         if (pWTIntFrame->frame.phaseIncrement) {
-            EAS_I32 oldMethod = 1 + (numSamples / pWTIntFrame->frame.phaseIncrement);
+            //EAS_I32 oldMethod = 1 + (numSamples / pWTIntFrame->frame.phaseIncrement);
             pWTIntFrame->numSamples =
                 (numSamples + pWTIntFrame->frame.phaseIncrement - 1) / pWTIntFrame->frame.phaseIncrement;
-            if (oldMethod != pWTIntFrame->numSamples) {
-                ALOGE("b/317780080 old %ld new %ld", oldMethod, pWTIntFrame->numSamples);
-                EAS_Report(_EAS_SEVERITY_DETAIL, "%s: old %ld new %ld\n", __func__, oldMethod, pWTIntFrame->numSamples);
-            }
+            // if (oldMethod != pWTIntFrame->numSamples) {
+            //     ALOGE("b/317780080 old %ld new %ld", oldMethod, pWTIntFrame->numSamples);
+            //     EAS_Report(_EAS_SEVERITY_DETAIL, "%s: old %d new %d\n", __func__, oldMethod, pWTIntFrame->numSamples);
+            // }
         } else {
             pWTIntFrame->numSamples = numSamples;
         }


### PR DESCRIPTION
## Description

Add format warnings to EAS_Report, and remove a check in WT_CheckSampleEnd.

The check is added in https://github.com/pedrolcl/sonivox/commit/f7c9ced540b7b0cdf312083a13fe6a8b06a35860. The new method is correct, so the check is not needed now.

## Related Issues



## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

