### PR TITLE
[BREAKING CHANGE] Change EAS_I32 and EAS_U32 to 32 bit back

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.14)
 
 project( sonivox
     LANGUAGES C CXX
-    VERSION 3.6.16.0
+    VERSION 4.0.0.0
 )
 
 # GoogleTest requires at least C++14

--- a/arm-wt-22k/host_src/eas_types.h
+++ b/arm-wt-22k/host_src/eas_types.h
@@ -131,8 +131,7 @@ typedef unsigned EAS_UINT;
 typedef int EAS_INT;
 typedef long EAS_LONG;
 
-typedef intptr_t EAS_ISIZE;
-typedef uintptr_t EAS_USIZE;
+typedef intptr_t EAS_IPTR;
 
 /* audio output type */
 typedef short EAS_PCM;

--- a/arm-wt-22k/host_src/eas_types.h
+++ b/arm-wt-22k/host_src/eas_types.h
@@ -85,12 +85,7 @@ typedef long EAS_RESULT;
 #define EAS_STREAM_BUFFERING                4
 #define EAS_BUFFER_FULL                     5
 
-/* EAS_STATE return codes */
-#if defined(_WIN64)
-typedef long long EAS_STATE;
-#else
 typedef long EAS_STATE;
-#endif
 typedef enum
 {
     EAS_STATE_READY = 0,
@@ -116,26 +111,21 @@ typedef enum
 
 /* boolean values */
 typedef unsigned EAS_BOOL;
-typedef unsigned char EAS_BOOL8;
+typedef uint8_t EAS_BOOL8;
 
 #define EAS_FALSE   0
 #define EAS_TRUE    1
 
 /* scalar variable definitions */
-typedef unsigned char EAS_U8;
-typedef signed char EAS_I8;
+typedef uint8_t EAS_U8;
+typedef int8_t EAS_I8;
 typedef char EAS_CHAR;
 
-typedef unsigned short EAS_U16;
-typedef short EAS_I16;
+typedef uint16_t EAS_U16;
+typedef int16_t EAS_I16;
 
-#if defined(_WIN64)
-typedef unsigned long long EAS_U32;
-typedef long long EAS_I32;
-#else
-typedef unsigned EAS_U32;
-typedef int EAS_I32;
-#endif
+typedef uint32_t EAS_U32;
+typedef int32_t EAS_I32;
 
 typedef unsigned EAS_UINT;
 typedef int EAS_INT;

--- a/arm-wt-22k/host_src/eas_types.h
+++ b/arm-wt-22k/host_src/eas_types.h
@@ -35,6 +35,8 @@
 #ifndef _EAS_TYPES_H
 #define _EAS_TYPES_H
 
+#include <stdint.h>
+
 /* EAS_RESULT return codes */
 typedef long EAS_RESULT;
 #define EAS_SUCCESS                         0
@@ -131,13 +133,16 @@ typedef short EAS_I16;
 typedef unsigned long long EAS_U32;
 typedef long long EAS_I32;
 #else
-typedef unsigned long EAS_U32;
-typedef long EAS_I32;
+typedef unsigned EAS_U32;
+typedef int EAS_I32;
 #endif
 
 typedef unsigned EAS_UINT;
 typedef int EAS_INT;
 typedef long EAS_LONG;
+
+typedef intptr_t EAS_ISIZE;
+typedef uintptr_t EAS_USIZE;
 
 /* audio output type */
 typedef short EAS_PCM;

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -520,7 +520,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         return result;
     if (temp != CHUNK_DLS)
     {
-        EAS_Report(_EAS_SEVERITY_ERROR, "Expected DLS chunk, got %08lx\n", temp);
+        EAS_Report(_EAS_SEVERITY_ERROR, "Expected DLS chunk, got %08x\n", temp);
         return EAS_ERROR_FILE_FORMAT;
     }
 
@@ -663,7 +663,7 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
         dls.pDLS = EAS_HWMalloc(dls.hwInstData, size);
         if (dls.pDLS == NULL)
         {
-            EAS_Report(_EAS_SEVERITY_ERROR, "EAS_HWMalloc failed for DLS memory allocation size %ld\n", size);
+            EAS_Report(_EAS_SEVERITY_ERROR, "EAS_HWMalloc failed for DLS memory allocation size %d\n", size);
             EAS_HWFree(dls.hwInstData, dls.wsmpData);
             return EAS_ERROR_MALLOC_FAILED;
         }
@@ -1146,7 +1146,7 @@ static EAS_RESULT Parse_wsmp (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WS
         return result;
     if (p->gain > 0)
     {
-        EAS_Report(_EAS_SEVERITY_DETAIL, "Positive gain [%ld] in DLS wsmp ignored, set to 0dB\n", p->gain);
+        EAS_Report(_EAS_SEVERITY_DETAIL, "Positive gain [%d] in DLS wsmp ignored, set to 0dB\n", p->gain);
         p->gain = 0;
     }
 
@@ -1163,7 +1163,7 @@ static EAS_RESULT Parse_wsmp (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_WS
     {
 
         if (ltemp > 1)
-            EAS_Report(_EAS_SEVERITY_WARNING, "DLS sample with %lu loops, ignoring extra loops\n", ltemp);
+            EAS_Report(_EAS_SEVERITY_WARNING, "DLS sample with %u loops, ignoring extra loops\n", ltemp);
 
         /* skip ahead to loop data */
         if ((result = EAS_HWFileSeek(pDLSData->hwInstData, pDLSData->fileHandle, pos + (EAS_I32) cbSize)) != EAS_SUCCESS)
@@ -1756,7 +1756,7 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     /* verify the parameters are valid */
     if (bank & 0x7fff8080)
     {
-        EAS_Report(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08lx\n", bank);
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08x\n", bank);
     }
     if (bank & 0x80000000u)
     {
@@ -1771,7 +1771,7 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     }
     if (program > 127)
     {
-        EAS_Report(_EAS_SEVERITY_WARNING, "DLS program number is out of range: %08lx\n", program);
+        EAS_Report(_EAS_SEVERITY_WARNING, "DLS program number is out of range: %08x\n", program);
         program &= 0x7f;
     }
 

--- a/arm-wt-22k/lib_src/eas_miditypes.h
+++ b/arm-wt-22k/lib_src/eas_miditypes.h
@@ -31,8 +31,9 @@
 #ifndef _EAS_MIDITYPES_H
 #define _EAS_MIDITYPES_H
 
-#include "eas_data.h"
 #include "eas_parser.h"
+
+typedef struct s_synth_tag S_SYNTH;
 
 /*----------------------------------------------------------------------------
  * S_MIDI_STREAM

--- a/arm-wt-22k/lib_src/eas_parser.h
+++ b/arm-wt-22k/lib_src/eas_parser.h
@@ -58,8 +58,8 @@ typedef struct
     EAS_RESULT (* EAS_CONST pfPause)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData);
     EAS_RESULT (* EAS_CONST pfResume)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData);
     EAS_RESULT (* EAS_CONST pfLocate)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 time, EAS_BOOL *pParserLocate);
-    EAS_RESULT (* EAS_CONST pfSetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
-    EAS_RESULT (* EAS_CONST pfGetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
+    EAS_RESULT (* EAS_CONST pfSetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value);
+    EAS_RESULT (* EAS_CONST pfGetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue);
     EAS_RESULT (* EAS_CONST pfGetMetaData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pMediaLength);
 } S_FILE_PARSER_INTERFACE;
 

--- a/arm-wt-22k/lib_src/eas_parser.h
+++ b/arm-wt-22k/lib_src/eas_parser.h
@@ -58,8 +58,8 @@ typedef struct
     EAS_RESULT (* EAS_CONST pfPause)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData);
     EAS_RESULT (* EAS_CONST pfResume)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData);
     EAS_RESULT (* EAS_CONST pfLocate)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 time, EAS_BOOL *pParserLocate);
-    EAS_RESULT (* EAS_CONST pfSetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value);
-    EAS_RESULT (* EAS_CONST pfGetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue);
+    EAS_RESULT (* EAS_CONST pfSetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
+    EAS_RESULT (* EAS_CONST pfGetData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
     EAS_RESULT (* EAS_CONST pfGetMetaData)(struct s_eas_data_tag *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pMediaLength);
 } S_FILE_PARSER_INTERFACE;
 

--- a/arm-wt-22k/lib_src/eas_public.c
+++ b/arm-wt-22k/lib_src/eas_public.c
@@ -98,7 +98,7 @@ static EAS_RESULT EAS_ParseEvents (S_EAS_DATA *pEASData, S_EAS_STREAM *pStream, 
  * value            - new value
  *----------------------------------------------------------------------------
 */
-EAS_RESULT EAS_SetStreamParameter (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_I32 param, EAS_ISIZE value)
+EAS_RESULT EAS_SetStreamParameter (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_I32 param, EAS_IPTR value)
 {
     S_FILE_PARSER_INTERFACE *pParserModule;
 
@@ -120,7 +120,7 @@ EAS_RESULT EAS_SetStreamParameter (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS
  * pValue           - pointer to variable to receive current setting
  *----------------------------------------------------------------------------
 */
-EAS_RESULT EAS_GetStreamParameter (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_I32 param, EAS_ISIZE *pValue)
+EAS_RESULT EAS_GetStreamParameter (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_I32 param, EAS_IPTR *pValue)
 {
     S_FILE_PARSER_INTERFACE *pParserModule;
 
@@ -161,7 +161,7 @@ EAS_BOOL EAS_StreamReady (S_EAS_DATA *pEASData, EAS_HANDLE pStream)
  * code in the parser.
  *----------------------------------------------------------------------------
 */
-EAS_RESULT EAS_IntSetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_INT param, EAS_ISIZE value)
+EAS_RESULT EAS_IntSetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_INT param, EAS_IPTR value)
 {
     S_SYNTH *pSynth;
 
@@ -171,7 +171,7 @@ EAS_RESULT EAS_IntSetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_IN
 
     /* get a pointer to the synth object and set it directly */
     /*lint -e{740} we are cheating by passing a pointer through this interface */
-    if (EAS_GetStreamParameter(pEASData, pStream, PARSER_DATA_SYNTH_HANDLE, (EAS_ISIZE*) &pSynth) != EAS_SUCCESS)
+    if (EAS_GetStreamParameter(pEASData, pStream, PARSER_DATA_SYNTH_HANDLE, (EAS_IPTR*) &pSynth) != EAS_SUCCESS)
         return EAS_ERROR_INVALID_PARAMETER;
 
     if (pSynth == NULL)
@@ -227,7 +227,7 @@ EAS_RESULT EAS_IntSetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_IN
  * get the parameter directly on the synth.
  *----------------------------------------------------------------------------
 */
-EAS_RESULT EAS_IntGetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_INT param, EAS_ISIZE *pValue)
+EAS_RESULT EAS_IntGetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_INT param, EAS_IPTR *pValue)
 {
     EAS_RESULT result;
     EAS_I32 value;
@@ -239,7 +239,7 @@ EAS_RESULT EAS_IntGetStrmParam (S_EAS_DATA *pEASData, EAS_HANDLE pStream, EAS_IN
 
     /* get a pointer to the synth object and retrieve data directly */
     /*lint -e{740} we are cheating by passing a pointer through this interface */
-    if (EAS_GetStreamParameter(pEASData, pStream, PARSER_DATA_SYNTH_HANDLE, (EAS_ISIZE*) &pSynth) != EAS_SUCCESS)
+    if (EAS_GetStreamParameter(pEASData, pStream, PARSER_DATA_SYNTH_HANDLE, (EAS_IPTR*) &pSynth) != EAS_SUCCESS)
         return EAS_ERROR_INVALID_PARAMETER;
 
     if (pSynth == NULL)
@@ -793,7 +793,7 @@ EAS_PUBLIC EAS_RESULT EAS_GetFileType (S_EAS_DATA *pEASData, EAS_HANDLE pStream,
 {
     if (!EAS_StreamReady (pEASData, pStream))
         return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
-    EAS_ISIZE value = 0;
+    EAS_IPTR value = 0;
     EAS_RESULT result = EAS_GetStreamParameter(pEASData, pStream, PARSER_DATA_FILE_TYPE, &value);
     *pFileType = value;
     return result;
@@ -1469,7 +1469,7 @@ EAS_PUBLIC EAS_RESULT EAS_RegisterMetaDataCallback (
     metadata.buffer = metaDataBuffer;
     metadata.bufferSize = metaDataBufSize;
     metadata.pUserData = pUserData;
-    return EAS_SetStreamParameter(pEASData, pStream, PARSER_DATA_METADATA_CB, (EAS_ISIZE) &metadata);
+    return EAS_SetStreamParameter(pEASData, pStream, PARSER_DATA_METADATA_CB, (EAS_IPTR) &metadata);
 }
 
 /*----------------------------------------------------------------------------
@@ -1482,7 +1482,7 @@ EAS_PUBLIC EAS_RESULT EAS_GetNoteCount (EAS_DATA_HANDLE pEASData, EAS_HANDLE pSt
 {
     if (!EAS_StreamReady(pEASData, pStream))
         return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
-    EAS_ISIZE value = 0;
+    EAS_IPTR value = 0;
     EAS_RESULT result = EAS_IntGetStrmParam(pEASData, pStream, PARSER_DATA_NOTE_COUNT, &value);
     *pNoteCount = (EAS_I32) value;
     return result;
@@ -1580,7 +1580,7 @@ EAS_PUBLIC EAS_RESULT EAS_OpenMIDIStream (EAS_DATA_HANDLE pEASData, EAS_HANDLE *
     /* use an existing synthesizer */
     else
     {
-        EAS_ISIZE value;
+        EAS_IPTR value;
         result = EAS_GetStreamParameter(pEASData, streamHandle, PARSER_DATA_SYNTH_HANDLE, &value);
         pMIDIStream->pSynth = (S_SYNTH*) value;
         VMIncRefCount(pMIDIStream->pSynth);
@@ -1774,7 +1774,7 @@ EAS_PUBLIC EAS_RESULT EAS_GetPolyphony (EAS_DATA_HANDLE pEASData, EAS_HANDLE pSt
 {
     if (!EAS_StreamReady(pEASData, pStream))
         return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
-    EAS_ISIZE value = 0;
+    EAS_IPTR value = 0;
     EAS_RESULT result = EAS_IntGetStrmParam(pEASData, pStream, PARSER_DATA_POLYPHONY, &value);
     *pPolyphonyCount = (EAS_I32) value;
     return result;
@@ -1875,7 +1875,7 @@ EAS_PUBLIC EAS_RESULT EAS_GetPriority (EAS_DATA_HANDLE pEASData, EAS_HANDLE pStr
     if (!EAS_StreamReady(pEASData, pStream))
         return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
 
-    EAS_ISIZE value = 0;
+    EAS_IPTR value = 0;
     EAS_RESULT result = EAS_IntGetStrmParam(pEASData, pStream, PARSER_DATA_PRIORITY, &value);
     *pPriority = (EAS_I32) value;
     return result;
@@ -1911,7 +1911,7 @@ EAS_PUBLIC EAS_RESULT EAS_SetVolume (EAS_DATA_HANDLE pEASData, EAS_HANDLE pStrea
     /* stream volume */
     if (pStream != NULL)
     {
-        EAS_ISIZE gainOffset;
+        EAS_IPTR gainOffset;
         EAS_RESULT result;
 
         if (!EAS_StreamReady(pEASData, pStream))
@@ -2406,7 +2406,7 @@ EAS_PUBLIC EAS_RESULT EAS_SetSoundLibrary (EAS_DATA_HANDLE pEASData, EAS_HANDLE 
     {
         if (!EAS_StreamReady(pEASData, pStream))
             return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
-        return EAS_IntSetStrmParam(pEASData, pStream, PARSER_DATA_EAS_LIBRARY, (EAS_ISIZE) pSndLib);
+        return EAS_IntSetStrmParam(pEASData, pStream, PARSER_DATA_EAS_LIBRARY, (EAS_IPTR) pSndLib);
     }
 
     return VMSetGlobalEASLib(pEASData->pVoiceMgr, pSndLib);
@@ -2496,7 +2496,7 @@ EAS_PUBLIC EAS_RESULT EAS_LoadDLSCollection (EAS_DATA_HANDLE pEASData, EAS_HANDL
 
         /* if a stream pStream is specified, point it to the DLS collection */
         if (pStream)
-            result = EAS_IntSetStrmParam(pEASData, pStream, PARSER_DATA_DLS_COLLECTION, (EAS_ISIZE) pDLS);
+            result = EAS_IntSetStrmParam(pEASData, pStream, PARSER_DATA_DLS_COLLECTION, (EAS_IPTR) pDLS);
 
         /* global DLS load */
         else

--- a/arm-wt-22k/lib_src/eas_smf.c
+++ b/arm-wt-22k/lib_src/eas_smf.c
@@ -384,7 +384,7 @@ EAS_RESULT SMF_Event (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_INT pars
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData) reserved for future use */
-EAS_RESULT SMF_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pState)
+EAS_RESULT SMF_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_STATE *pState)
 {
     S_SMF_DATA* pSMFData;
 
@@ -609,7 +609,7 @@ EAS_RESULT SMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData) reserved for future use */
-EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value)
+EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value)
 {
     S_SMF_DATA *pSMFData;
 
@@ -696,7 +696,7 @@ EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 pa
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData) reserved for future use */
-EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue)
+EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue)
 {
     S_SMF_DATA *pSMFData;
 
@@ -732,7 +732,7 @@ EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 pa
 #endif
 
         case PARSER_DATA_SYNTH_HANDLE:
-            *pValue = (EAS_I32) pSMFData->pSynth;
+            *pValue = (EAS_ISIZE) pSMFData->pSynth;
             break;
 
         default:

--- a/arm-wt-22k/lib_src/eas_smf.c
+++ b/arm-wt-22k/lib_src/eas_smf.c
@@ -609,7 +609,7 @@ EAS_RESULT SMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData) reserved for future use */
-EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value)
+EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value)
 {
     S_SMF_DATA *pSMFData;
 
@@ -696,7 +696,7 @@ EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 pa
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData) reserved for future use */
-EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue)
+EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue)
 {
     S_SMF_DATA *pSMFData;
 
@@ -732,7 +732,7 @@ EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 pa
 #endif
 
         case PARSER_DATA_SYNTH_HANDLE:
-            *pValue = (EAS_ISIZE) pSMFData->pSynth;
+            *pValue = (EAS_IPTR) pSMFData->pSynth;
             break;
 
         default:

--- a/arm-wt-22k/lib_src/eas_smf.h
+++ b/arm-wt-22k/lib_src/eas_smf.h
@@ -40,8 +40,8 @@ EAS_RESULT SMF_Close (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 EAS_RESULT SMF_Reset (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 EAS_RESULT SMF_Pause (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 EAS_RESULT SMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
-EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
-EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
+EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value);
+EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue);
 EAS_RESULT SMF_ParseHeader (EAS_HW_DATA_HANDLE hwInstData, S_SMF_DATA *pSMFData);
 
 #endif /* end _EAS_SMF_H */

--- a/arm-wt-22k/lib_src/eas_smf.h
+++ b/arm-wt-22k/lib_src/eas_smf.h
@@ -40,8 +40,8 @@ EAS_RESULT SMF_Close (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 EAS_RESULT SMF_Reset (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 EAS_RESULT SMF_Pause (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 EAS_RESULT SMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
-EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value);
-EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue);
+EAS_RESULT SMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
+EAS_RESULT SMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
 EAS_RESULT SMF_ParseHeader (EAS_HW_DATA_HANDLE hwInstData, S_SMF_DATA *pSMFData);
 
 #endif /* end _EAS_SMF_H */

--- a/arm-wt-22k/lib_src/eas_tonecontrol.c
+++ b/arm-wt-22k/lib_src/eas_tonecontrol.c
@@ -69,8 +69,8 @@ static EAS_RESULT TC_Close (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT TC_Reset (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT TC_Pause (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT TC_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
-static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value);
-static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue);
+static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
+static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
 static EAS_RESULT TC_ParseHeader (S_EAS_DATA *pEASData, S_TC_DATA* pData);
 static EAS_RESULT TC_StartNote (S_EAS_DATA *pEASData, S_TC_DATA* pData, EAS_INT parserMode, EAS_I8 note);
 static EAS_RESULT TC_GetRepeat (S_EAS_DATA *pEASData, S_TC_DATA* pData, EAS_INT parserMode);
@@ -386,7 +386,7 @@ static EAS_RESULT TC_Event (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_IN
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData) reserved for future use */
-static EAS_RESULT TC_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pState)
+static EAS_RESULT TC_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_STATE *pState)
 {
     S_TC_DATA* pData;
 
@@ -573,7 +573,7 @@ static EAS_RESULT TC_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData, pInstData, value) reserved for future use */
-static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value)
+static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value)
 {
     /* we don't parse any metadata, but we need to return success here */
     if (param == PARSER_DATA_METADATA_CB)
@@ -600,7 +600,7 @@ static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_
  *----------------------------------------------------------------------------
 */
 /*lint -e{715} common with other parsers */
-static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue)
+static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue)
 {
     S_TC_DATA *pData;
 
@@ -613,7 +613,7 @@ static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_
             break;
 
         case PARSER_DATA_SYNTH_HANDLE:
-            *pValue = (EAS_I32) pData->pSynth;
+            *pValue = (EAS_ISIZE) pData->pSynth;
             break;
 
     default:

--- a/arm-wt-22k/lib_src/eas_tonecontrol.c
+++ b/arm-wt-22k/lib_src/eas_tonecontrol.c
@@ -69,8 +69,8 @@ static EAS_RESULT TC_Close (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT TC_Reset (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT TC_Pause (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT TC_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
-static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
-static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
+static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value);
+static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue);
 static EAS_RESULT TC_ParseHeader (S_EAS_DATA *pEASData, S_TC_DATA* pData);
 static EAS_RESULT TC_StartNote (S_EAS_DATA *pEASData, S_TC_DATA* pData, EAS_INT parserMode, EAS_I8 note);
 static EAS_RESULT TC_GetRepeat (S_EAS_DATA *pEASData, S_TC_DATA* pData, EAS_INT parserMode);
@@ -573,7 +573,7 @@ static EAS_RESULT TC_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
  *----------------------------------------------------------------------------
 */
 /*lint -esym(715, pEASData, pInstData, value) reserved for future use */
-static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value)
+static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value)
 {
     /* we don't parse any metadata, but we need to return success here */
     if (param == PARSER_DATA_METADATA_CB)
@@ -600,7 +600,7 @@ static EAS_RESULT TC_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_
  *----------------------------------------------------------------------------
 */
 /*lint -e{715} common with other parsers */
-static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue)
+static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue)
 {
     S_TC_DATA *pData;
 
@@ -613,7 +613,7 @@ static EAS_RESULT TC_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_
             break;
 
         case PARSER_DATA_SYNTH_HANDLE:
-            *pValue = (EAS_ISIZE) pData->pSynth;
+            *pValue = (EAS_IPTR) pData->pSynth;
             break;
 
     default:

--- a/arm-wt-22k/lib_src/eas_wtengine.c
+++ b/arm-wt-22k/lib_src/eas_wtengine.c
@@ -106,8 +106,8 @@ void WT_VoiceGain (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
-        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
@@ -209,8 +209,8 @@ void WT_Interpolate (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
-        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
@@ -316,8 +316,8 @@ void WT_InterpolateNoLoop (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
-        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
@@ -422,8 +422,8 @@ void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
-        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
@@ -496,8 +496,8 @@ void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
-        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }
@@ -650,8 +650,8 @@ void WT_InterpolateMono (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame)
         android_errorWriteLog(0x534e4554, "26366256");
         return;
     } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
-        ALOGE("b/317780080 clip numSamples %ld -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
         android_errorWriteLog(0x534e4554, "317780080");
         numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
     }

--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -487,7 +487,7 @@ EAS_BOOL WT_CheckSampleEnd (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame, E
             android_errorWriteLog(0x534e4554, "26366256");
             pWTIntFrame->numSamples = 0;
         } else if (pWTIntFrame->numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
-            EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %ld > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, pWTIntFrame->numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+            EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, pWTIntFrame->numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
             ALOGE("b/317780080 clip numSamples %ld -> %d",
                   pWTIntFrame->numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
             android_errorWriteLog(0x534e4554, "317780080");

--- a/arm-wt-22k/lib_src/eas_xmf.c
+++ b/arm-wt-22k/lib_src/eas_xmf.c
@@ -92,8 +92,8 @@ static EAS_RESULT XMF_Close (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT XMF_Reset (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT XMF_Pause (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT XMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
-static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value);
-static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue);
+static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
+static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
 static EAS_RESULT XMF_FindFileContents (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFData);
 static EAS_RESULT XMF_ReadNode (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFData, EAS_I32 nodeOffset, EAS_I32 endOffset, EAS_I32 *pLength, EAS_I32 depth);
 static EAS_RESULT XMF_ReadVLQ (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle, EAS_U32 *remainingBytes, EAS_I32 *value);
@@ -208,7 +208,7 @@ static EAS_RESULT XMF_CheckFileType (S_EAS_DATA *pEASData, EAS_FILE_HANDLE fileH
     /* locate the SMF and DLS contents */
     if ((result = XMF_FindFileContents(pEASData->hwInstData, pXMFData)) != EAS_SUCCESS)
     {
-        EAS_Report(_EAS_SEVERITY_ERROR, "Failed to parse XMF file: %d\n", result);
+        EAS_Report(_EAS_SEVERITY_ERROR, "Failed to parse XMF file: %ld\n", result);
         EAS_HWFree(pEASData->hwInstData, pXMFData);
         return result;
     }
@@ -352,7 +352,7 @@ static EAS_RESULT XMF_Event (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I
  *
  *----------------------------------------------------------------------------
 */
-static EAS_RESULT XMF_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pState)
+static EAS_RESULT XMF_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_STATE *pState)
 {
     return SMF_State(pEASData, ((S_XMF_DATA*) pInstData)->pSMFData, pState);
 }
@@ -496,7 +496,7 @@ static EAS_RESULT XMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
  *
  *----------------------------------------------------------------------------
 */
-static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 value)
+static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value)
 {
     return SMF_SetData(pEASData, ((S_XMF_DATA*) pInstData)->pSMFData, param, value);
 }
@@ -519,7 +519,7 @@ static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS
  *
  *----------------------------------------------------------------------------
 */
-static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue)
+static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue)
 {
     EAS_RESULT result;
 
@@ -816,7 +816,7 @@ static EAS_RESULT XMF_ReadNode (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFD
             strm.avail_out = unpackedSize;
             result = inflateInit(&strm);
             if (result != Z_OK) {
-                EAS_Report(_EAS_SEVERITY_ERROR, "Failed to initialize zlib for unpacking XMF data: %d\n", result);
+                EAS_Report(_EAS_SEVERITY_ERROR, "Failed to initialize zlib for unpacking XMF data: %ld\n", result);
                 EAS_HWFree(hwInstData, unpackedData);
                 return EAS_FAILURE;
             }
@@ -849,7 +849,7 @@ static EAS_RESULT XMF_ReadNode (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFD
                         goto ZLIBReadFin;
                     }
                     if (result != Z_OK) {
-                        EAS_Report(_EAS_SEVERITY_ERROR, "ZLIB unpacking error in XMF node: %d\n", result);
+                        EAS_Report(_EAS_SEVERITY_ERROR, "ZLIB unpacking error in XMF node: %ld\n", result);
                         EAS_HWFree(hwInstData, unpackedData);
                         inflateEnd(&strm);
                         return EAS_ERROR_FILE_FORMAT;

--- a/arm-wt-22k/lib_src/eas_xmf.c
+++ b/arm-wt-22k/lib_src/eas_xmf.c
@@ -92,8 +92,8 @@ static EAS_RESULT XMF_Close (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT XMF_Reset (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT XMF_Pause (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
 static EAS_RESULT XMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData);
-static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value);
-static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue);
+static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value);
+static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue);
 static EAS_RESULT XMF_FindFileContents (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFData);
 static EAS_RESULT XMF_ReadNode (EAS_HW_DATA_HANDLE hwInstData, S_XMF_DATA *pXMFData, EAS_I32 nodeOffset, EAS_I32 endOffset, EAS_I32 *pLength, EAS_I32 depth);
 static EAS_RESULT XMF_ReadVLQ (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle, EAS_U32 *remainingBytes, EAS_I32 *value);
@@ -496,7 +496,7 @@ static EAS_RESULT XMF_Resume (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData)
  *
  *----------------------------------------------------------------------------
 */
-static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE value)
+static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR value)
 {
     return SMF_SetData(pEASData, ((S_XMF_DATA*) pInstData)->pSMFData, param, value);
 }
@@ -519,7 +519,7 @@ static EAS_RESULT XMF_SetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS
  *
  *----------------------------------------------------------------------------
 */
-static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_ISIZE *pValue)
+static EAS_RESULT XMF_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_IPTR *pValue)
 {
     EAS_RESULT result;
 

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -287,7 +287,7 @@ int renderFile(const char *fileName)
     mPCMBufferSize = sizeof(EAS_PCM) * mEASConfig->mixBufferSize * mEASConfig->numChannels;
     mAudioBuffer = alloca(mPCMBufferSize);
     if (mAudioBuffer == NULL) {
-        fprintf(stderr, "Failed to allocate memory of size: %ld", mPCMBufferSize);
+        fprintf(stderr, "Failed to allocate memory of size: %d", mPCMBufferSize);
         ok = EXIT_FAILURE;
         goto cleanup;
     }
@@ -315,7 +315,7 @@ int renderFile(const char *fileName)
         }
 
         if (count != mEASConfig->mixBufferSize) {
-            fprintf(stderr, "Only %ld out of %ld frames rendered\n", count, mEASConfig->mixBufferSize);
+            fprintf(stderr, "Only %d out of %d frames rendered\n", count, mEASConfig->mixBufferSize);
             ok = EXIT_FAILURE;
             break;
         }
@@ -401,42 +401,42 @@ int main (int argc, char **argv)
         case 'r':
             reverb_type = atoi(optarg);
             if ((reverb_type < 0) || (reverb_type > 4)) {
-                fprintf (stderr, "invalid reverb preset: %ld\n", reverb_type);
+                fprintf (stderr, "invalid reverb preset: %d\n", reverb_type);
                 return EXIT_FAILURE;
             }
             break;
         case 'w':
             reverb_wet = atoi(optarg);
             if ((reverb_wet < 0) || (reverb_wet > 32767)) {
-                fprintf (stderr, "invalid reverb wet: %ld\n", reverb_wet);
+                fprintf (stderr, "invalid reverb wet: %d\n", reverb_wet);
                 return EXIT_FAILURE;
             }
             break;
         case 'n':
             reverb_dry = atoi(optarg);
             if ((reverb_dry < 0) || (reverb_dry > 32767)) {
-                fprintf (stderr, "invalid reverb dry: %ld\n", reverb_dry);
+                fprintf (stderr, "invalid reverb dry: %d\n", reverb_dry);
                 return EXIT_FAILURE;
             }
             break;
         case 'c':
             chorus_type = atoi(optarg);
             if ((chorus_type < 0) || (chorus_type > 4)) {
-                fprintf (stderr, "invalid chorus preset: %ld\n", chorus_type);
+                fprintf (stderr, "invalid chorus preset: %d\n", chorus_type);
                 return EXIT_FAILURE;
             }
             break;
         case 'l':
             chorus_level = atoi(optarg);
             if ((chorus_level < 0) || (chorus_level > 32767)) {
-                fprintf (stderr, "invalid chorus level: %ld\n", chorus_level);
+                fprintf (stderr, "invalid chorus level: %d\n", chorus_level);
                 return EXIT_FAILURE;
             }
             break;
         case 'g':
             playback_gain = atoi(optarg);
             if ((playback_gain < 0) || (playback_gain > 100)) {
-                fprintf (stderr, "invalid playback gain: %ld\n", playback_gain);
+                fprintf (stderr, "invalid playback gain: %d\n", playback_gain);
                 return EXIT_FAILURE;
             }
             break;


### PR DESCRIPTION
## Breaking Change

ABI is broken because the size of EAS_I32 and EAS_U32 (used in public functions) is changed.

## Description

Change EAS_I32 and EAS_U32 to 32 bit back, which fixes fake "wsmp postive gain" warnings.

> The tons of "positive gain" messages is actually a bug. The host wrapper always read DWORD (unsigned) and convert to 64-bit EAS_x32, which works well in EAS_U32, but converting to a signed integer is different from an unsigned one.
Now EAS_x32 is 32-bit.

## Related Issues

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

