### PR TITLE
Implement SoundFont 2 parser and rewrite DCF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ list(APPEND SOURCES
 #arm-wt-22k/lib_src/jet.c
   arm-wt-22k/lib_src/wt_200k_G.c
   arm-wt-22k/src/rmidi.c
+  arm-wt-22k/lib_src/eas_sf2.c
 )
 
 if (NEW_HOST_WRAPPER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(BUILD_EXAMPLE "Build and install the example program" TRUE)
 option(BUILD_TESTING "Build the unit tests" TRUE)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Whether to create position-independent targets" TRUE)
 option(NEW_HOST_WRAPPER "Use the new host wrapper" TRUE)
+option(SF2_SUPPORT "Enable SF2 support and float DCF" TRUE)
 set(MAX_VOICES 64 CACHE STRING "Maximum number of voices")
 
 include(CMakeDependentOption)
@@ -133,6 +134,13 @@ else()
     list(APPEND SOURCES arm-wt-22k/host_src/eas_hostmm.c)
 endif()
 
+if (SF2_SUPPORT)
+    list(APPEND SOURCES arm-wt-22k/lib_src/eas_sf2.c arm-wt-22k/lib_src/eas_filter_float.c)
+else()
+    message(STATUS "SF2 support disabled.")
+    list(APPEND SOURCES arm-wt-22k/lib_src/eas_filter.c)
+endif()
+
 configure_file(arm-wt-22k/host_src/eas.cmake libsonivox/eas.h @ONLY)
 
 list(APPEND HEADERS
@@ -187,6 +195,10 @@ endif()
 
 if(ZLIB_FOUND)
     target_compile_definitions( sonivox-objects PRIVATE _ZLIB_UNPACKER )
+endif()
+
+if (SF2_SUPPORT)
+    target_compile_definitions( sonivox-objects PRIVATE _SF2_SUPPORT _FLOAT_DCF )
 endif()
 
 target_include_directories( sonivox-objects PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ list(APPEND SOURCES
 #arm-wt-22k/lib_src/jet.c
   arm-wt-22k/lib_src/wt_200k_G.c
   arm-wt-22k/src/rmidi.c
-  arm-wt-22k/lib_src/eas_sf2.c
 )
 
 if (NEW_HOST_WRAPPER)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 This project is a fork of the Android Open Source Project 'platform_external_sonivox', including a CMake based build system to be used not on Android, but on any other computer Operating System.
 Google licensed this work originally named Sonivox EAS (Embedded Audio Synthesis) from the company Sonic Network Inc. under the terms of the Apache License 2.0.
 
-This is a Wave Table synthesizer, not using external soundfont files by default but embedded samples. It also supports external DLS soundfont files for better rendering quality. It is also a real time GM synthesizer. It consumes very little resources, so it may be indicated in projects for small embedded devices.
+This is a Wave Table synthesizer, not using external soundfont files by default but embedded samples. It also supports external DLS or SF2 soundfont files for better rendering quality. It is also a real time GM synthesizer. It consumes very little resources, so it may be indicated in projects for small embedded devices.
 There is neither MIDI input nor Audio output facilities included in the library. You need to provide your own input/output.
 
 You may find several projects already using this library as a git submodule:
@@ -38,7 +38,7 @@ The build system has the following options:
 * `BUILD_TESTING`: ON by default, to control if the unit tests are built, which require Google Test.
 * `BUILD_EXAMPLE`: ON by default, to build and install the example program.
 * `CMAKE_POSITION_INDEPENDENT_CODE`: Whether to create position-independent targets. ON By default.
-* `NEW_HOST_WRAPPER`: Uses the new CRT-based host wrapper for faster DLS loading. ON by default.
+* `NEW_HOST_WRAPPER`: Uses the new CRT-based host wrapper for faster file loading. ON by default.
 * `MAX_VOICES`: Maximum number of voices. 64 by default.
 
 See also the [CMake documentation](https://cmake.org/cmake/help/latest/index.html) for common build options.
@@ -63,19 +63,21 @@ You can use the program to listen MIDI files or to create audio files (like MP3 
 
 ~~~
 $ ./sonivoxrender -h
-Usage: ./sonivoxrender [-h|--help] [-v|--version] [-d|--dls file.dls] [-r|--reverb 0..4] [-w|--wet 0..32767] [-n|--dry 0..32767] [-c|--chorus 0..4] [-l|--level 0..32767] [-g|--gain 0..100] [-V|--Verbosity 0..5] file.mid ...
+Usage: ./sonivoxrender [-h|--help] [-v|--version] [-d|--dls soundfont] [-r|--reverb 0..4] [-w|--wet 0..32767] [-n|--dry 0..32767] [-c|--chorus 0..4] [-l|--level 0..32767] [-g|--gain 0..196] [-V|--Verbosity 0..5] [-R|--reverb-post-mix] [-C|--chorus-post-mix] file.mid ...
 Render standard MIDI files into raw PCM audio.
 Options:
-    -h, --help          this help message.
-    -v, --version       sonivox version.
-    -d, --dls file.dls  DLS soundfont.
-    -r, --reverb n      reverb preset: 0=no, 1=large hall, 2=hall, 3=chamber, 4=room.
-    -w, --wet n         reverb wet: 0..32767.
-    -n, --dry n         reverb dry: 0..32767.
-    -c, --chorus n      chorus preset: 0=no, 1..4=presets.
-    -l, --level n       chorus level: 0..32767.
-    -g, --gain n        master gain: 0..100.
-    -V, --Verbosity n   Verbosity: 0=no, 1=fatals, 2=errors, 3=warnings, 4=infos, 5=details.
+        -h, --help              this help message.
+        -v, --version           sonivox version.
+        -d, --dls soundfont     DLS or SF2 soundfont.
+        -r, --reverb n          reverb preset: 0=no, 1=large hall, 2=hall, 3=chamber, 4=room.
+        -w, --wet n             reverb wet: 0..32767.
+        -n, --dry n             reverb dry: 0..32767.
+        -c, --chorus n          chorus preset: 0=no, 1..4=presets.
+        -l, --level n           chorus level: 0..32767.
+        -g, --gain n            master gain: 0..196. 100 = +0dB.
+        -V, --Verbosity n       Verbosity: 0=no, 1=fatals, 2=errors, 3=warnings, 4=infos, 5=details
+        -R, --reverb-post-mix   ignore CC91 reverb send.
+        -C, --chorus-post-mix   ignore CC93 chorus send.
 ~~~
 
 The following examples assume the default option USE_44KHZ=ON:
@@ -115,6 +117,12 @@ Example 7: pipe the rendered audio thru the [FFmpeg](https://ffmpeg.org/)'s 'ffp
 This has the advantage of being multiplatform. Depending on the FFmpeg installed version, you may need instead:
 
     $ sonivoxrender ants.mid | ffplay -i - -f s16le -ar 44.1k -ch_layout stereo -nodisp -autoexit -loglevel quiet
+
+Example 8: pipe the rendered audio thru the ['mpv' media player](https://mpv.io/):
+
+    $ sonivoxrender ants.mid | mpv --demuxer=rawaudio -demuxer-rawaudio-format=s16le --demuxer-rawaudio-rate=44100 --demuxer-rawaudio-channels=2 --no-video -
+
+Besides being multiplatform, this supports progress view and better navigation (backed by in-memory cache).
 
 You may replace "ants.mid" by another MIDI or XMF file, like "test/res/testmxmf.mxmf"
 

--- a/arm-wt-22k/lib_src/eas_dlssynth.c
+++ b/arm-wt-22k/lib_src/eas_dlssynth.c
@@ -266,7 +266,7 @@ static void DLS_UpdateFilter (S_SYNTH_VOICE *pVoice, S_WT_VOICE *pWTVoice, S_WT_
     /* no need to calculate filter coefficients if it is bypassed */
     if (pDLSArt->filterCutoff == DEFAULT_DLS_FILTER_CUTOFF_FREQUENCY)
     {
-        pIntFrame->frame.k = 0;
+        pIntFrame->frame.b02 = 0;
         return;
     }
 
@@ -300,7 +300,7 @@ static void DLS_UpdateFilter (S_SYNTH_VOICE *pVoice, S_WT_VOICE *pWTVoice, S_WT_
 
     if (cutoff == 13500) 
     {
-        pIntFrame->frame.k = 0; // bypass filter
+        pIntFrame->frame.b02 = 0; // bypass filter
         return;
     }
 
@@ -352,8 +352,10 @@ EAS_RESULT DLS_StartVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNTH_VOIC
 #endif
 
     /* initialize the filter states */
-    pWTVoice->filter.z1 = 0;
-    pWTVoice->filter.z2 = 0;
+    pWTVoice->filter.y1 = 0;
+    pWTVoice->filter.y2 = 0;
+    pWTVoice->filter.x1 = 0;
+    pWTVoice->filter.x2 = 0;
 
     /* initialize the oscillator */
 #if defined (_8_BIT_SAMPLES)

--- a/arm-wt-22k/lib_src/eas_dlssynth.c
+++ b/arm-wt-22k/lib_src/eas_dlssynth.c
@@ -266,7 +266,11 @@ static void DLS_UpdateFilter (S_SYNTH_VOICE *pVoice, S_WT_VOICE *pWTVoice, S_WT_
     /* no need to calculate filter coefficients if it is bypassed */
     if (pDLSArt->filterCutoff == DEFAULT_DLS_FILTER_CUTOFF_FREQUENCY)
     {
-        pIntFrame->frame.b02 = 0;
+#ifdef _FLOAT_DCF
+        pIntFrame->frame.b02 = 0.0f;
+#else
+        pIntFrame->frame.k = 0;
+#endif
         return;
     }
 
@@ -298,9 +302,13 @@ static void DLS_UpdateFilter (S_SYNTH_VOICE *pVoice, S_WT_VOICE *pWTVoice, S_WT_
     /*lint -e{702} use shift for performance */
     cutoff += (pVoice->note * pDLSArt->keyNumToFc) >> 7;
 
-    if (cutoff == 13500) 
+    if (cutoff == 13500) // bypass filter
     {
-        pIntFrame->frame.b02 = 0; // bypass filter
+#ifdef _FLOAT_DCF
+        pIntFrame->frame.b02 = 0.0f;
+#else
+        pIntFrame->frame.k = 0;
+#endif
         return;
     }
 
@@ -352,10 +360,7 @@ EAS_RESULT DLS_StartVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNTH_VOIC
 #endif
 
     /* initialize the filter states */
-    pWTVoice->filter.y1 = 0;
-    pWTVoice->filter.y2 = 0;
-    pWTVoice->filter.x1 = 0;
-    pWTVoice->filter.x2 = 0;
+    memset(&pWTVoice->filter, 0, sizeof(S_FILTER_CONTROL));
 
     /* initialize the oscillator */
 #if defined (_8_BIT_SAMPLES)

--- a/arm-wt-22k/lib_src/eas_dlssynth.c
+++ b/arm-wt-22k/lib_src/eas_dlssynth.c
@@ -298,14 +298,11 @@ static void DLS_UpdateFilter (S_SYNTH_VOICE *pVoice, S_WT_VOICE *pWTVoice, S_WT_
     /*lint -e{702} use shift for performance */
     cutoff += (pVoice->note * pDLSArt->keyNumToFc) >> 7;
 
-    /* subtract the A5 offset and the sampling frequency */
-    cutoff -= FILTER_CUTOFF_FREQ_ADJUST + A5_PITCH_OFFSET_IN_CENTS;
-
-    /* limit the cutoff frequency */
-    if (cutoff > FILTER_CUTOFF_MAX_PITCH_CENTS)
-        cutoff = FILTER_CUTOFF_MAX_PITCH_CENTS;
-    else if (cutoff < FILTER_CUTOFF_MIN_PITCH_CENTS)
-        cutoff = FILTER_CUTOFF_MIN_PITCH_CENTS;
+    if (cutoff == 13500) 
+    {
+        pIntFrame->frame.k = 0; // bypass filter
+        return;
+    }
 
     WT_SetFilterCoeffs(pIntFrame, cutoff, pDLSArt->filterQandFlags & FILTER_Q_MASK);
 }

--- a/arm-wt-22k/lib_src/eas_filter.c
+++ b/arm-wt-22k/lib_src/eas_filter.c
@@ -1,0 +1,328 @@
+#if defined(_FILTER_ENABLED) && !defined(_FLOAT_DCF)
+#include "eas_wtengine.h"
+#include "eas_report.h"
+#include "eas_audioconst.h"
+#include "eas_math.h"
+
+#include "log/log.h"
+#include <cutils/log.h>
+
+/* adjust the filter cutoff frequency to the sample rate */
+#if defined (_SAMPLE_RATE_8000)
+#define FILTER_CUTOFF_FREQ_ADJUST       0
+#elif defined (_SAMPLE_RATE_16000)
+#define FILTER_CUTOFF_FREQ_ADJUST       1200
+#elif defined (_SAMPLE_RATE_20000)
+#define FILTER_CUTOFF_FREQ_ADJUST       1586
+#elif defined (_SAMPLE_RATE_22050)
+#define FILTER_CUTOFF_FREQ_ADJUST       1756
+#elif defined (_SAMPLE_RATE_24000)
+#define FILTER_CUTOFF_FREQ_ADJUST       1902
+#elif defined (_SAMPLE_RATE_32000)
+#define FILTER_CUTOFF_FREQ_ADJUST       2400
+#elif defined (_SAMPLE_RATE_44100)
+#define FILTER_CUTOFF_FREQ_ADJUST       2956
+#elif defined (_SAMPLE_RATE_48000)
+#define FILTER_CUTOFF_FREQ_ADJUST       3102
+#else
+#error "_SAMPLE_RATE_XXXXX must be defined to valid rate"
+#endif
+
+/*----------------------------------------------------------------------------
+ * WT_VoiceFilter
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Implements a 2-pole IIR filter
+ *
+ * Inputs:
+ *
+ * Outputs:
+ *
+ *----------------------------------------------------------------------------
+*/
+void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
+{
+    EAS_PCM *pAudioBuffer;
+    EAS_I32 k;
+    EAS_I32 b1;
+    EAS_I32 b2;
+    EAS_I32 z1;
+    EAS_I32 z2;
+    EAS_I32 acc0;
+    EAS_I32 acc1;
+    EAS_I32 numSamples;
+
+    /* initialize some local variables */
+    numSamples = pWTIntFrame->numSamples;
+    if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
+        ALOGE("b/26366256");
+        android_errorWriteLog(0x534e4554, "26366256");
+        return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
+    }
+    pAudioBuffer = pWTIntFrame->pAudioBuffer;
+
+    z1 = pFilter->z1;
+    z2 = pFilter->z2;
+    b1 = -pWTIntFrame->frame.b1;
+
+    /*lint -e{702} <avoid divide> */
+    b2 = -pWTIntFrame->frame.b2 >> 1;
+
+    /*lint -e{702} <avoid divide> */
+    k = pWTIntFrame->frame.k >> 1;
+
+    while (numSamples--)
+    {
+
+        /* do filter calculations */
+        acc0 = *pAudioBuffer;
+        acc1 = z1 * b1;
+        acc1 += z2 * b2;
+        acc0 = acc1 + k * acc0;
+        z2 = z1;
+
+        /*lint -e{702} <avoid divide> */
+        z1 = acc0 >> 14;
+        *pAudioBuffer++ = (EAS_I16) z1;
+    }
+
+    /* save delay values     */
+    pFilter->z1 = (EAS_I16) z1;
+    pFilter->z2 = (EAS_I16) z2;
+}
+
+/*----------------------------------------------------------------------------
+ * coef
+ *----------------------------------------------------------------------------
+ * Table of filter coefficients for low-pass filter
+ *----------------------------------------------------------------------------
+ *
+ * polynomial coefficients are based on 8kHz sampling frequency
+ * filter coef b2 = k2 = k2g0*k^0 + k2g1*k^1*(2^x) + k2g2*k^2*(2^x)
+ *
+ *where k2g0, k2g1, k2g2 are from the truncated power series expansion on theta
+ *(k*2^x = theta, but we incorporate the k along with the k2g0, k2g1, k2g2)
+ *note: this is a power series in 2^x, not k*2^x
+ *where k = (2*pi*440)/8kHz == convert octaves to radians
+ *
+ *  so actually, the following coefs listed as k2g0, k2g1, k2g2 are really
+ *  k2g0*k^0 = k2g0
+ *  k2g1*k^1
+ *  k2g2*k^2
+ *
+ *
+ * filter coef n1 = numerator = n1g0*k^0 + n1g1*k^1*(2^x) + n1g2*k^2*(2^x) + n1g3*k^3*(2^x)
+ *
+ *where n1g0, n1g1, n1g2, n1g3 are from the truncated power series expansion on theta
+ *(k*2^x = theta, but we incorporate the k along with the n1g0, n1g1, n1g2, n2g3)
+ *note: this is a power series in 2^x, not k*2^x
+ *where k = (2*pi*440)/8kHz == convert octaves to radians
+ *we also include the optimization factor of 0.81
+ *
+ *  so actually, the following coefs listed as n1g0, n1g1, n1g2, n2g3 are really
+ *  n1g0*k^0 = n1g0
+ *  n1g1*k^1
+ *  n1g2*k^2
+ *  n1g3*k^3
+ *
+ *  NOTE that n1g0 == n1g1 == 0, always, so we only need to store n1g2 and n1g3
+ *----------------------------------------------------------------------------
+*/
+
+static const EAS_I16 nk1g0 = -32768;
+static const EAS_I16 nk1g2 = 1580;
+static const EAS_I16 k2g0 = 32767;
+
+static const EAS_I16 k2g1[] =
+{
+        -11324, /* k2g1[0] = -0.3455751918948761 */
+        -10387, /* k2g1[1] = -0.3169878073928751 */
+        -9528,  /* k2g1[2] = -0.29076528753345476 */
+        -8740,  /* k2g1[3] = -0.2667120011011279 */
+        -8017,  /* k2g1[4] = -0.24464850028971705 */
+        -7353,  /* k2g1[5] = -0.22441018194495696 */
+        -6745,  /* k2g1[6] = -0.20584605955455101 */
+        -6187,  /* k2g1[7] = -0.18881763682420102 */
+        -5675,  /* k2g1[8] = -0.1731978744360067 */
+        -5206,  /* k2g1[9] = -0.15887024228080968 */
+        -4775,  /* k2g1[10] = -0.14572785009373057 */
+        -4380,  /* k2g1[11] = -0.13367265000706827 */
+        -4018,  /* k2g1[12] = -0.1226147050712642 */
+        -3685,  /* k2g1[13] = -0.11247151828678581 */
+        -3381,  /* k2g1[14] = -0.10316741714122014 */
+        -3101,  /* k2g1[15] = -0.0946329890599603 */
+        -2844,  /* k2g1[16] = -0.08680456355870586 */
+        -2609,  /* k2g1[17] = -0.07962373723441349 */
+        -2393,  /* k2g1[18] = -0.07303693805092666 */
+        -2195,  /* k2g1[19] = -0.06699502566866912 */
+        -2014,  /* k2g1[20] = -0.06145292483669077 */
+        -1847,  /* k2g1[21] = -0.056369289112013346 */
+        -1694,  /* k2g1[22] = -0.05170619239747895 */
+        -1554,  /* k2g1[23] = -0.04742884599684141 */
+        -1426,  /* k2g1[24] = -0.043505339076210514 */
+        -1308,  /* k2g1[25] = -0.03990640059558053 */
+        -1199,  /* k2g1[26] = -0.03660518093435039 */
+        -1100,  /* k2g1[27] = -0.03357705158166837 */
+        -1009,  /* k2g1[28] = -0.030799421397205727 */
+        -926,   /* k2g1[29] = -0.028251568071585884 */
+        -849    /* k2g1[30] = -0.025914483529091967 */
+};
+
+static const EAS_I16 k2g2[] =
+{
+        1957,   /* k2g2[0] = 0.059711106626580836 */
+        1646,   /* k2g2[1] = 0.05024063501786333 */
+        1385,   /* k2g2[2] = 0.042272226217199664 */
+        1165,   /* k2g2[3] = 0.03556764576567844 */
+        981,    /* k2g2[4] = 0.029926444346999134 */
+        825,    /* k2g2[5] = 0.025179964880280382 */
+        694,    /* k2g2[6] = 0.02118630011706455 */
+        584,    /* k2g2[7] = 0.01782604998793514 */
+        491,    /* k2g2[8] = 0.014998751854573014 */
+        414,    /* k2g2[9] = 0.012619876941179595 */
+        348,    /* k2g2[10] = 0.010618303146468736 */
+        293,    /* k2g2[11] = 0.008934188679954682 */
+        246,    /* k2g2[12] = 0.007517182949855368 */
+        207,    /* k2g2[13] = 0.006324921212866403 */
+        174,    /* k2g2[14] = 0.005321757979794424 */
+        147,    /* k2g2[15] = 0.004477701309210577 */
+        123,    /* k2g2[16] = 0.00376751612730811 */
+        104,    /* k2g2[17] = 0.0031699697655869644 */
+        87,     /* k2g2[18] = 0.00266719715992703 */
+        74,     /* k2g2[19] = 0.0022441667321724647 */
+        62,     /* k2g2[20] = 0.0018882309854916855 */
+        52,     /* k2g2[21] = 0.0015887483774966232 */
+        44,     /* k2g2[22] = 0.0013367651661223448 */
+        37,     /* k2g2[23] = 0.0011247477162958733 */
+        31,     /* k2g2[24] = 0.0009463572640678758 */
+        26,     /* k2g2[25] = 0.0007962604042473498 */
+        22,     /* k2g2[26] = 0.0006699696356181593 */
+        18,     /* k2g2[27] = 0.0005637091964589207 */
+        16,     /* k2g2[28] = 0.00047430217920125243 */
+        13,     /* k2g2[29] = 0.00039907554925166274 */
+        11      /* k2g2[30] = 0.00033578022828973666 */
+};
+
+static const EAS_I16 n1g2[] =
+{
+        3170,   /* n1g2[0] = 0.0967319927350769 */
+        3036,   /* n1g2[1] = 0.0926446051254155 */
+        2908,   /* n1g2[2] = 0.08872992911818503 */
+        2785,   /* n1g2[3] = 0.08498066682523227 */
+        2667,   /* n1g2[4] = 0.08138982872895201 */
+        2554,   /* n1g2[5] = 0.07795072065216213 */
+        2446,   /* n1g2[6] = 0.0746569312785634 */
+        2343,   /* n1g2[7] = 0.07150232020051943 */
+        2244,   /* n1g2[8] = 0.06848100647187474 */
+        2149,   /* n1g2[9] = 0.06558735764447099 */
+        2058,   /* n1g2[10] = 0.06281597926792246 */
+        1971,   /* n1g2[11] = 0.06016170483307614 */
+        1888,   /* n1g2[12] = 0.05761958614040857 */
+        1808,   /* n1g2[13] = 0.05518488407540374 */
+        1732,   /* n1g2[14] = 0.052853059773715245 */
+        1659,   /* n1g2[15] = 0.05061976615964251 */
+        1589,   /* n1g2[16] = 0.04848083984214659 */
+        1521,   /* n1g2[17] = 0.046432293353298 */
+        1457,   /* n1g2[18] = 0.04447030771468711 */
+        1396,   /* n1g2[19] = 0.04259122531793907 */
+        1337,   /* n1g2[20] = 0.040791543106060944 */
+        1280,   /* n1g2[21] = 0.03906790604290942 */
+        1226,   /* n1g2[22] = 0.037417100858604564 */
+        1174,   /* n1g2[23] = 0.035836050059229754 */
+        1125,   /* n1g2[24] = 0.03432180618965023 */
+        1077,   /* n1g2[25] = 0.03287154633875494 */
+        1032,   /* n1g2[26] = 0.03148256687687814 */
+        988,    /* n1g2[27] = 0.030152278415589925 */
+        946,    /* n1g2[28] = 0.028878200980459685 */
+        906,    /* n1g2[29] = 0.02765795938779331 */
+        868     /* n1g2[30] = 0.02648927881672521 */
+};
+
+static const EAS_I16 n1g3[] =
+{
+        -548,   /* n1g3[0] = -0.016714088475899017 */
+        -481,   /* n1g3[1] = -0.014683605122742116 */
+        -423,   /* n1g3[2] = -0.012899791676436092 */
+        -371,   /* n1g3[3] = -0.01133268185193299 */
+        -326,   /* n1g3[4] = -0.00995594976868754 */
+        -287,   /* n1g3[5] = -0.008746467702146129 */
+        -252,   /* n1g3[6] = -0.00768391756106361 */
+        -221,   /* n1g3[7] = -0.006750449563854721 */
+        -194,   /* n1g3[8] = -0.005930382380083576 */
+        -171,   /* n1g3[9] = -0.005209939699767622 */
+        -150,   /* n1g3[10] = -0.004577018805123356 */
+        -132,   /* n1g3[11] = -0.004020987256990177 */
+        -116,   /* n1g3[12] = -0.003532504280467257 */
+        -102,   /* n1g3[13] = -0.00310336384922047 */
+        -89,    /* n1g3[14] = -0.002726356832432369 */
+        -78,    /* n1g3[15] = -0.002395149888601605 */
+        -69,    /* n1g3[16] = -0.0021041790717285314 */
+        -61,    /* n1g3[17] = -0.0018485563625771063 */
+        -53,    /* n1g3[18] = -0.001623987554831628 */
+        -47,    /* n1g3[19] = -0.0014267001167177025 */
+        -41,    /* n1g3[20] = -0.0012533798162347005 */
+        -36,    /* n1g3[21] = -0.0011011150453668693 */
+        -32,    /* n1g3[22] = -0.0009673479079754438 */
+        -28,    /* n1g3[23] = -0.0008498312496971563 */
+        -24,    /* n1g3[24] = -0.0007465909079943587 */
+        -21,    /* n1g3[25] = -0.0006558925481952733 */
+        -19,    /* n1g3[26] = -0.0005762125284029567 */
+        -17,    /* n1g3[27] = -0.0005062123038325457 */
+        -15,    /* n1g3[28] = -0.0004447159405951901 */
+        -13,    /* n1g3[29] = -0.00039069036118270117 */
+        -11     /* n1g3[30] = -0.00034322798979677605 */
+};
+
+/*----------------------------------------------------------------------------
+ * WT_SetFilterCoeffs()
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Update the Filter parameters
+ *
+ * Inputs:
+ * pVoice - ptr to the voice whose filter we want to update
+ * pEASData - pointer to overall EAS data structure
+ *
+ * Outputs:
+ *
+ * Side Effects:
+ * - updates Filter values for the given voice
+ *----------------------------------------------------------------------------
+*/
+void WT_SetFilterCoeffs (S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance)
+{
+    EAS_I32 temp;
+
+    /*
+    Convert the cutoff, which has had A5 subtracted, using the 2^x approx
+    Note, this cutoff is related to theta cutoff by
+    theta = k * 2^x
+    We use 2^x and incorporate k in the power series coefs instead
+    */
+    cutoff = EAS_Calculate2toX(cutoff);
+
+    /* calculate b2 coef */
+    temp = k2g1[resonance] + MULT_AUDIO_COEF(cutoff, k2g2[resonance]);
+    temp = k2g0 + MULT_AUDIO_COEF(cutoff, temp);
+    pIntFrame->frame.b2 = temp;
+
+    /* calculate b1 coef */
+    temp = MULT_AUDIO_COEF(cutoff, nk1g2);
+    temp = nk1g0 + MULT_AUDIO_COEF(cutoff, temp);
+    temp += MULT_AUDIO_COEF(temp, pIntFrame->frame.b2);
+    pIntFrame->frame.b1 = temp >> 1;
+
+    /* calculate K coef */
+    temp = n1g2[resonance] + MULT_AUDIO_COEF(cutoff, n1g3[resonance]);
+    temp = MULT_AUDIO_COEF(cutoff, temp);
+    temp = MULT_AUDIO_COEF(cutoff, temp);
+    pIntFrame->frame.k = temp;
+}
+
+#endif

--- a/arm-wt-22k/lib_src/eas_filter.h
+++ b/arm-wt-22k/lib_src/eas_filter.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "eas_types.h"
+
+typedef struct s_wt_int_frame_tag S_WT_INT_FRAME;
+
+#if defined(_FILTER_ENABLED)
+/*----------------------------------------------------------------------------
+ * S_FILTER_CONTROL data structure
+ *----------------------------------------------------------------------------
+*/
+typedef struct s_filter_control_tag
+{
+#ifdef _FLOAT_DCF
+    EAS_I32     y1;                             /* 1 sample delay output */
+    EAS_I32     y2;                             /* 2 sample delay output */
+    EAS_I32     x1;                             /* 1 sample delay input */
+    EAS_I32     x2;                             /* 2 sample delay input */
+#else
+    EAS_I16     z1;                             /* 1 sample delay state variable */
+    EAS_I16     z2;                             /* 2 sample delay state variable */
+#endif
+} S_FILTER_CONTROL;
+
+void WT_VoiceFilter (S_FILTER_CONTROL* pFilter, S_WT_INT_FRAME *pWTIntFrame);
+void WT_SetFilterCoeffs (S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance);
+#endif

--- a/arm-wt-22k/lib_src/eas_filter_float.c
+++ b/arm-wt-22k/lib_src/eas_filter_float.c
@@ -1,0 +1,135 @@
+#if defined(_FILTER_ENABLED) && defined(_FLOAT_DCF)
+#include "eas_wtengine.h"
+#include "eas_report.h"
+#include "eas_audioconst.h"
+
+#include "log/log.h"
+#include <cutils/log.h>
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+/*----------------------------------------------------------------------------
+ * WT_VoiceFilter
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Implements a 2-pole IIR filter
+ *
+ * Inputs:
+ *
+ * Outputs:
+ *
+ *----------------------------------------------------------------------------
+*/
+void WT_VoiceFilter (S_FILTER_CONTROL *pFilter, S_WT_INT_FRAME *pWTIntFrame)
+{
+    if (pWTIntFrame->frame.b02 == 0) {
+        return;
+    }
+
+    /* initialize some local variables */
+    EAS_I32 numSamples = pWTIntFrame->numSamples;
+    if (numSamples <= 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples <= 0\n", __func__);
+        ALOGE("b/26366256");
+        android_errorWriteLog(0x534e4554, "26366256");
+        return;
+    } else if (numSamples > BUFFER_SIZE_IN_MONO_SAMPLES) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "%s: numSamples %d > %d BUFFER_SIZE_IN_MONO_SAMPLES\n", __func__, numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        ALOGE("b/317780080 clip numSamples %d -> %d", numSamples, BUFFER_SIZE_IN_MONO_SAMPLES);
+        android_errorWriteLog(0x534e4554, "317780080");
+        numSamples = BUFFER_SIZE_IN_MONO_SAMPLES;
+    }
+    EAS_PCM *pAudioBuffer = pWTIntFrame->pAudioBuffer;
+
+    // General 2-pole IIR transfer function is:
+    //  H(z) = (b0 + b1 * z^-1 + b2 * z^-2) / (1 + a1 * z^-1 + a2 * z^-2)
+    // Its difference equation is:
+    //  y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] - a1 * y[n-1] - a2 * y[n-2]
+    const float b1 = pWTIntFrame->frame.b1;
+    const float b02 = pWTIntFrame->frame.b02;
+    const float a1 = pWTIntFrame->frame.a1;
+    const float a2 = pWTIntFrame->frame.a2;
+
+    EAS_I32 y1 = pFilter->y1; // y[n-1]
+    EAS_I32 y2 = pFilter->y2; // y[n-2]
+    EAS_I32 x1 = pFilter->x1; // x[n-1]
+    EAS_I32 x2 = pFilter->x2; // x[n-2]
+
+    const float limit = 1 << 15;
+
+    while (numSamples--)
+    {
+        float acc0 = b02 * (*pAudioBuffer) + b1 * x1 + b02 * x2 - a1 * y1 - a2 * y2;
+
+        // saturate
+        if (acc0 > limit - 1) acc0 = limit - 1;
+        if (acc0 < -limit) acc0 = -limit;
+
+        y2 = y1;
+        y1 = (EAS_I32) acc0;
+        x2 = x1;
+        x1 = *pAudioBuffer;
+
+        *pAudioBuffer++ = y1; // y[n]
+    }
+
+    /* save delay values */
+    pFilter->y1 = y1;
+    pFilter->y2 = y2;
+    pFilter->x1 = x1;
+    pFilter->x2 = x2;
+}
+
+/* 
+ * Compute filter coefficients for a 2nd-order (2-pole) low-pass IIR filter
+ *
+ * General 2-pole IIR transfer function is:
+ *  H(z) = (b0 + b1 * z^-1 + b2 * z^-2) / (1 + a1 * z^-1 + a2 * z^-2)
+ * Its difference equation is:
+ *  y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] - a1 * y[n-1] - a2 * y[n-2]
+ *
+ */
+void WT_SetFilterCoeffs(S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance) {
+    double fc = pow(2.0, (cutoff - 6900.0) / 1200.0) * 440.0;
+
+    const double fs = (double)_OUTPUT_SAMPLE_RATE;
+    const double min_fc = fs / 240.0;
+    const double max_fc = fs / 2.0;
+    fc = fmax(fmin(fc, max_fc), min_fc);
+
+    // EAS's resonance is in 0.75dB steps
+    const double resonance_dB = fmax(resonance / 10.0, 0.0);
+
+    // filter pole angle
+    const double theta = 2.0 * M_PI * fc / fs;
+
+    const double T = 1.0 / _OUTPUT_SAMPLE_RATE;
+    const double omega0 = 2.0 * _OUTPUT_SAMPLE_RATE * tan(theta / 2);
+    double q;
+    if (resonance_dB < 1e-9) {
+        q = 1 / sqrt(2); // default Q for Butterworth filter
+    } else {
+        q = pow(10.0, resonance_dB / 20.0);
+    }
+
+    const double omega0T = omega0 * T;
+    const double D = 4 + 2 * omega0T / q + omega0T * omega0T;
+
+    // compute filter coefficients
+    const double a1 = (-8 + 2 * (omega0T * omega0T)) / D;
+    const double a2 = (4 - 2 * omega0T / q + omega0T * omega0T) / D;
+    double b02 = omega0T * omega0T / D;
+    double b1 = 2 * (omega0T * omega0T) / D;
+
+    // apply resonance gain compensation
+    const double g = pow(10.0, -resonance_dB / 40.0);
+    b02 *= g;
+    b1 *= g;
+
+    pIntFrame->frame.b1 = b1;
+    pIntFrame->frame.b02 = b02;
+    pIntFrame->frame.a1 = a1;
+    pIntFrame->frame.a2 = a2;
+}
+#endif

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -519,7 +519,12 @@ EAS_RESULT DLSParser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle,
     {
         if (temp == CHUNK_TYPE('s', 'f', 'b', 'k')) {
             // let SF2Parser takeover
+#ifdef _SF2_SUPPORT
             return SF2Parser(hwInstData, fileHandle, offset, ppDLS);
+#else
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2 support is not enabled\n");
+            return EAS_ERROR_FEATURE_NOT_AVAILABLE;
+#endif
         }
         EAS_Report(_EAS_SEVERITY_ERROR, "Expected DLS chunk, got %08x\n", temp);
         return EAS_ERROR_FILE_FORMAT;
@@ -763,8 +768,10 @@ EAS_RESULT DLSCleanup (EAS_HW_DATA_HANDLE hwInstData, S_DLS *pDLS)
             if (--pDLS->refCount == 0) {
                 if (pDLS->libType == DLSLIB_TYPE_DLS) {
                     EAS_HWFree(hwInstData, pDLS);
+#ifdef _SF2_SUPPORT
                 } else if (pDLS->libType == DLSLIB_TYPE_SF2) {
                     return SF2Cleanup(hwInstData, pDLS);
+#endif
                 } else {
                     return EAS_ERROR_DATA_INCONSISTENCY;
                 }

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -2865,27 +2865,23 @@ EAS_I8 DLSConvertPan (EAS_I32 pan)
 }
 
 /*----------------------------------------------------------------------------
- * ConvertQ()
+ * DLSConvertQ()
  *----------------------------------------------------------------------------
- * Convert the DLS filter resonance to an index value used by the synth
- * that accesses tables of coefficients based on the Q.
+ * q: Resonance peak's relative gain to pass magnitude in 0.1dB steps
  *----------------------------------------------------------------------------
 */
-EAS_U8 DLSConvertQ (EAS_I32 q)
+EAS_U16 DLSConvertQ (EAS_I32 q)
 {
-
     /* apply limits */
-    if (q <= 0)
+    if (q <= 0) {
         return 0;
+    }
 
-    /* convert to table index */
-    /*lint -e{704} use shift for performance */
-    q = (FILTER_Q_CONVERSION_FACTOR * q + 0x4000) >> 15;
+    if (q > FILTER_Q_MASK) {
+        return FILTER_Q_MASK;
+    }
 
-    /* apply upper limit */
-    if (q >= FILTER_RESONANCE_NUM_ENTRIES)
-        q = FILTER_RESONANCE_NUM_ENTRIES - 1;
-    return (EAS_U8) q;
+    return q;
 }
 
 #ifdef _DEBUG_DLS

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -125,7 +125,9 @@
 #include "eas_report.h"
 #include <string.h>
 
+#ifdef _SF2_SUPPORT
 #include "eas_sf2.h"
+#endif
 
 #if defined(_16_BIT_SAMPLES)
 // for mp3 decoding

--- a/arm-wt-22k/lib_src/eas_mdls.h
+++ b/arm-wt-22k/lib_src/eas_mdls.h
@@ -290,6 +290,11 @@ EAS_RESULT DLSCleanup (EAS_HW_DATA_HANDLE hwInstData, S_DLS *pDLS);
 void DLSAddRef (S_DLS *pDLS);
 EAS_I16 DLSConvertDelay (EAS_I32 timeCents);
 EAS_I16 DLSConvertRate (EAS_I32 timeCents);
+EAS_U8 DLSConvertQ (EAS_I32 q);
+EAS_I8 DLSConvertPan (EAS_I32 pan);
+EAS_I16 DLSConvertPitchToPhaseInc (EAS_I32 pitchCents);
+EAS_I16 DLSConvertSustain (EAS_I32 sustain);
+EAS_I16 DLSConvertSampleRate (EAS_U32 sampleRate);
 
 #ifdef _STANDALONE_CONVERTER
 void DLSConvParams (S_DLS_PARAMS *pParams, EAS_BOOL set);

--- a/arm-wt-22k/lib_src/eas_mdls.h
+++ b/arm-wt-22k/lib_src/eas_mdls.h
@@ -145,18 +145,6 @@ typedef struct
 #endif
 
 /*
- * FILTER_Q_CONVERSION_FACTOR convers the 0.1dB steps in the DLS
- * file to our internal 0.75 dB steps. The value is calculated
- * as follows:
- *
- * 32768 / (10 * <step-size in dB>)
- *
- * FILTER_RESONANCE_NUM_ENTRIES is the number of entries in the table
-*/
-#define FILTER_Q_CONVERSION_FACTOR          4369
-#define FILTER_RESONANCE_NUM_ENTRIES        31
-
-/*
  * Multiplier to convert DLS gain units (10ths of a dB) to a
  * power-of-two exponent for conversion to linear gain using our
  * piece-wise linear approximator. Note that we ignore the lower
@@ -290,7 +278,7 @@ EAS_RESULT DLSCleanup (EAS_HW_DATA_HANDLE hwInstData, S_DLS *pDLS);
 void DLSAddRef (S_DLS *pDLS);
 EAS_I16 DLSConvertDelay (EAS_I32 timeCents);
 EAS_I16 DLSConvertRate (EAS_I32 timeCents);
-EAS_U8 DLSConvertQ (EAS_I32 q);
+EAS_U16 DLSConvertQ (EAS_I32 q);
 EAS_I8 DLSConvertPan (EAS_I32 pan);
 EAS_I16 DLSConvertPitchToPhaseInc (EAS_I32 pitchCents);
 EAS_I16 DLSConvertSustain (EAS_I32 sustain);

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -1911,7 +1911,7 @@ static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOpe
 
     // modulators
     for (EAS_U32 i = 0; i < modCount; i++) {
-        const char* myOffset = pMods + (MOD_SIZE * (EAS_IPTR)i);
+        const char* myOffset = (char*)pMods + (MOD_SIZE * (EAS_IPTR)i);
         const EAS_U16 modSrc = *(EAS_U16*)myOffset;
         const EAS_U16 modDest = *(EAS_I16*)(myOffset + 2);
         const EAS_I16 modAmount = *(EAS_U16*)(myOffset + 4);

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -22,7 +22,7 @@
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
-enum E_RIFF_IDENTIFIER : int {
+enum {
     RIFF_IDENTIFIER = 0x52494646, // 'RIFF'
     LIST_IDENTIFIER = 0x4C495354, // 'LIST'
     SFBK_IDENTIFIER = 0x7366626B, // 'sfbk'
@@ -43,7 +43,7 @@ enum E_RIFF_IDENTIFIER : int {
 };
 
 // SFGenerator enums
-enum E_SFGenerator : EAS_U16 {
+enum E_SFGenerator {
     sfg_startAddrsOffset = 0,
 	sfg_endAddrsOffset = 1,
 	sfg_startloopAddrsOffset = 2,
@@ -108,7 +108,7 @@ enum E_SFGenerator : EAS_U16 {
 };
 
 // SFModulator enums
-enum E_SFModulator : EAS_U16 {
+enum E_SFModulator {
 	sfm_noController = 0,
 	sfm_noteOnVolume = 2,
 	sfm_noteOnKeyNumber = 3,
@@ -120,20 +120,20 @@ enum E_SFModulator : EAS_U16 {
 };
 
 // SFTransform enums
-enum E_SFTransform : EAS_U16 { 
+enum E_SFTransform { 
 	sft_Linear = 0,
 	sft_AbsoluteValue = 2
 };
 
 // SFControllerType enums
-enum E_SFControllerType : EAS_U8 { 
+enum E_SFControllerType { 
 	sfct_Linear = 0, 
 	sfct_Concave = 1, 
 	sfct_Convex = 2, 
 	sfct_Switch = 3 
 };
 
-enum E_SF2_REC_SIZES : int {
+enum E_SF2_REC_SIZES {
     PHDR_SIZE = 38,
     SHDR_SIZE = 46,
     INST_SIZE = 22,
@@ -143,12 +143,12 @@ enum E_SF2_REC_SIZES : int {
     GEN_SIZE = 4,
 };
 
-enum E_SF2Parser_LIMITS : int {
+enum E_SF2Parser_LIMITS {
     MAX_GENS_IN_MERGED_REGION = 65536,
     MAX_MODS_IN_MERGED_REGION = 65536
 };
 
-enum E_SAMPLE_TYPE_FLAGS : EAS_U16 {
+enum E_SAMPLE_TYPE_FLAGS {
     SAMPLETYPE_COMPRESSED = 0x10
 };
 

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -1,6 +1,13 @@
+// SoundFont 2.04 File Parser
+//
+// Note that this is not a complete implementation. It only supports what EAS's DLS synth can do.
+// Unsupported features are reported in the log.
+//
+// SF3 (https://github.com/FluidSynth/fluidsynth/wiki/SoundFont3Format) is recognized (with the sample link flag correctly set),
+// though not supported, and will not load.
+
 #include "eas_sf2.h"
 #include "eas_host.h"
-#include "eas_math.h"
 #include "eas_report.h"
 #include "eas_mdls.h"
 #include <stdlib.h>
@@ -14,8 +21,6 @@
 #endif
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #define min(a,b) ((a) < (b) ? (a) : (b))
-
-#define clamp(v, l, r) (max((l), min((v), (r))))
 
 enum : int {
     RIFF_IDENTIFIER = 0x52494646, // 'RIFF'
@@ -144,7 +149,7 @@ enum : int {
 };
 
 enum : EAS_U16 {
-    SAMPLETYPE_COMPRESSED = 0x10 // See https://github.com/FluidSynth/fluidsynth/wiki/SoundFont3Format
+    SAMPLETYPE_COMPRESSED = 0x10
 };
 
 // internal data when parsing
@@ -1891,6 +1896,7 @@ static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOpe
         *loopMode = 1; // loop forever
     } else if (gens[sfg_sampleModes] == 3) { // loop and release
         // TODO: eas does not support this
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: sampleModes 3 'loop and release' is not supported at generator entry\n");
         *loopMode = 1; // loop forever
     } else { // no loop
         *loopMode = 0;

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -2081,7 +2081,7 @@ static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOpe
 
     // TODO: EAS's filter implementation is weird, SF2's defaul value (13500 20kHz) still cause a significant amount of treble reduction
     // TODO: This line will disable the filter. A new filter implementation may be needed
-    pDLSArt->filterCutoff = DEFAULT_DLS_FILTER_CUTOFF_FREQUENCY;
+    //pDLSArt->filterCutoff = DEFAULT_DLS_FILTER_CUTOFF_FREQUENCY;
 
     return EAS_SUCCESS;
 }

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -2079,9 +2079,5 @@ static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOpe
         pDLSArt->filterQandFlags &= ~FLAG_DLS_VELOCITY_SENSITIVE;
     }
 
-    // TODO: EAS's filter implementation is weird, SF2's defaul value (13500 20kHz) still cause a significant amount of treble reduction
-    // TODO: This line will disable the filter. A new filter implementation may be needed
-    //pDLSArt->filterCutoff = DEFAULT_DLS_FILTER_CUTOFF_FREQUENCY;
-
     return EAS_SUCCESS;
 }

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -22,7 +22,7 @@
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
-enum : int {
+enum E_RIFF_IDENTIFIER : int {
     RIFF_IDENTIFIER = 0x52494646, // 'RIFF'
     LIST_IDENTIFIER = 0x4C495354, // 'LIST'
     SFBK_IDENTIFIER = 0x7366626B, // 'sfbk'
@@ -43,7 +43,7 @@ enum : int {
 };
 
 // SFGenerator enums
-enum : EAS_U16 {
+enum E_SFGenerator : EAS_U16 {
     sfg_startAddrsOffset = 0,
 	sfg_endAddrsOffset = 1,
 	sfg_startloopAddrsOffset = 2,
@@ -108,7 +108,7 @@ enum : EAS_U16 {
 };
 
 // SFModulator enums
-enum : EAS_U16 {
+enum E_SFModulator : EAS_U16 {
 	sfm_noController = 0,
 	sfm_noteOnVolume = 2,
 	sfm_noteOnKeyNumber = 3,
@@ -120,20 +120,20 @@ enum : EAS_U16 {
 };
 
 // SFTransform enums
-enum : EAS_U16 { 
+enum E_SFTransform : EAS_U16 { 
 	sft_Linear = 0,
 	sft_AbsoluteValue = 2
 };
 
 // SFControllerType enums
-enum : EAS_U8 { 
+enum E_SFControllerType : EAS_U8 { 
 	sfct_Linear = 0, 
 	sfct_Concave = 1, 
 	sfct_Convex = 2, 
 	sfct_Switch = 3 
 };
 
-enum : int {
+enum E_SF2_REC_SIZES : int {
     PHDR_SIZE = 38,
     SHDR_SIZE = 46,
     INST_SIZE = 22,
@@ -143,12 +143,12 @@ enum : int {
     GEN_SIZE = 4,
 };
 
-enum : int {
+enum E_SF2Parser_LIMITS : int {
     MAX_GENS_IN_MERGED_REGION = 65536,
     MAX_MODS_IN_MERGED_REGION = 65536
 };
 
-enum : EAS_U16 {
+enum E_SAMPLE_TYPE_FLAGS : EAS_U16 {
     SAMPLETYPE_COMPRESSED = 0x10
 };
 

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -1911,7 +1911,7 @@ static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOpe
 
     // modulators
     for (EAS_U32 i = 0; i < modCount; i++) {
-        const void* myOffset = pMods + (MOD_SIZE * (EAS_IPTR)i);
+        const char* myOffset = pMods + (MOD_SIZE * (EAS_IPTR)i);
         const EAS_U16 modSrc = *(EAS_U16*)myOffset;
         const EAS_U16 modDest = *(EAS_I16*)(myOffset + 2);
         const EAS_I16 modAmount = *(EAS_U16*)(myOffset + 4);

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -1,0 +1,2081 @@
+#include "eas_sf2.h"
+#include "eas_host.h"
+#include "eas_math.h"
+#include "eas_report.h"
+#include "eas_mdls.h"
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+#define max(a,b) ((a) > (b) ? (a) : (b))
+#define min(a,b) ((a) < (b) ? (a) : (b))
+
+#define clamp(v, l, r) (max((l), min((v), (r))))
+
+enum : int {
+    RIFF_IDENTIFIER = 0x52494646, // 'RIFF'
+    LIST_IDENTIFIER = 0x4C495354, // 'LIST'
+    SFBK_IDENTIFIER = 0x7366626B, // 'sfbk'
+    INFO_IDENTIFIER = 0x494E464F, // 'INFO'
+    SDTA_IDENTIFIER = 0x73647461, // 'sdta'
+    SMPL_IDENTIFIER = 0x736D706C, // 'smpl'
+    SM24_IDENTIFIER = 0x736D3234, // 'sm24'
+    PDTA_IDENTIFIER = 0x70647461, // 'pdta'
+    PHDR_IDENTIFIER = 0x70686472, // 'phdr'
+    PBAG_IDENTIFIER = 0x70626167, // 'pbag'
+    PMOD_IDENTIFIER = 0x706D6F64, // 'pmod'
+    PGEN_IDENTIFIER = 0x7067656E, // 'pgen'
+    INST_IDENTIFIER = 0x696E7374, // 'inst'
+    IBAG_IDENTIFIER = 0x69626167, // 'ibag'
+    IMOD_IDENTIFIER = 0x696D6F64, // 'imod'
+    IGEN_IDENTIFIER = 0x6967656E, // 'igen'
+    SHDR_IDENTIFIER = 0x73686472, // 'shdr'
+};
+
+// SFGenerator enums
+enum : EAS_U16 {
+    sfg_startAddrsOffset = 0,
+	sfg_endAddrsOffset = 1,
+	sfg_startloopAddrsOffset = 2,
+	sfg_endloopAddrsOffset = 3,
+	sfg_startAddrsCoarseOffset = 4,
+	sfg_modLfoToPitch = 5,
+	sfg_vibLfoToPitch = 6,
+	sfg_modEnvToPitch = 7,
+	sfg_initialFilterFc = 8,
+	sfg_initialFilterQ = 9,
+	sfg_modLfoToFilterFc = 10,
+	sfg_modEnvToFilterFc = 11,
+    sfg_endAddrsCoarseOffset = 12,
+	sfg_modLfoToVolume = 13,
+	sfg_unused1 = 14,
+	sfg_chorusEffectsSend = 15,
+	sfg_reverbEffectsSend = 16,
+	sfg_pan = 17,
+	sfg_unused2 = 18,
+	sfg_unused3 = 19,
+	sfg_unused4 = 20,
+	sfg_delayModLFO = 21,
+	sfg_freqModLFO = 22,
+	sfg_delayVibLFO = 23,
+	sfg_freqVibLFO = 24,
+	sfg_delayModEnv = 25,
+	sfg_attackModEnv = 26,
+	sfg_holdModEnv = 27,
+	sfg_decayModEnv = 28,
+	sfg_sustainModEnv = 29,
+	sfg_releaseModEnv = 30,
+	sfg_keynumToModEnvHold = 31,
+	sfg_keynumToModEnvDecay = 32,
+	sfg_delayVolEnv = 33,
+	sfg_attackVolEnv = 34,
+	sfg_holdVolEnv = 35,
+	sfg_decayVolEnv = 36,
+	sfg_sustainVolEnv = 37,
+	sfg_releaseVolEnv = 38,
+	sfg_keynumToVolEnvHold = 39,
+	sfg_keynumToVolEnvDecay = 40,
+	sfg_instrument = 41,
+	sfg_reserved1 = 42,
+	sfg_keyRange = 43,
+	sfg_velRange = 44,
+	sfg_startloopAddrsCoarseOffset = 45,
+	sfg_keynum = 46,
+    sfg_velocity = 47,
+	sfg_initialAttenuation = 48,
+	sfg_reserved2 = 49,
+	sfg_endloopAddrsCoarseOffset = 50,
+	sfg_coarseTune = 51,
+	sfg_fineTune = 52,
+	sfg_sampleID = 53,
+	sfg_sampleModes = 54,
+	sfg_reserved3 = 55,
+	sfg_scaleTuning = 56,
+	sfg_exclusiveClass = 57,
+	sfg_overridingRootKey = 58,
+	sfg_unused5 = 59,
+	sfg_endOper = 60
+};
+
+// SFModulator enums
+enum : EAS_U16 {
+	sfm_noController = 0,
+	sfm_noteOnVolume = 2,
+	sfm_noteOnKeyNumber = 3,
+	sfm_polyPressure = 10,
+	sfm_channelPressure = 13,
+	sfm_pitchWheel = 14,
+	sfm_pitchWheelSensitivity = 16,
+	sfm_link = 127
+};
+
+// SFTransform enums
+enum : EAS_U16 { 
+	sft_Linear = 0,
+	sft_AbsoluteValue = 2
+};
+
+// SFControllerType enums
+enum : EAS_U8 { 
+	sfct_Linear = 0, 
+	sfct_Concave = 1, 
+	sfct_Convex = 2, 
+	sfct_Switch = 3 
+};
+
+enum : int {
+    PHDR_SIZE = 38,
+    SHDR_SIZE = 46,
+    INST_SIZE = 22,
+    IBAG_SIZE = 4,
+    PBAG_SIZE = 4,
+    MOD_SIZE = 10,
+    GEN_SIZE = 4,
+};
+
+enum : int {
+    MAX_GENS_IN_MERGED_REGION = 65536,
+    MAX_MODS_IN_MERGED_REGION = 65536
+};
+
+enum : EAS_U16 {
+    SAMPLETYPE_COMPRESSED = 0x10 // See https://github.com/FluidSynth/fluidsynth/wiki/SoundFont3Format
+};
+
+// internal data when parsing
+typedef struct S_SF2_PARSER
+{
+    EAS_HW_DATA_HANDLE hwInstData;
+    EAS_FILE_HANDLE fileHandle;
+    EAS_I32 fileOffset;
+    EAS_U32 fileSize;
+
+    S_DLS* pDLS;
+
+    EAS_U32 smplOffset; // points to the start of raw data
+    EAS_U32 smplSize; // in bytes
+
+    EAS_U32 sampleCount;
+    EAS_U32 sampleDLSSize; // size in S_DLS
+    EAS_U32 sampleDLSWritten; // in bytes
+    EAS_U32* pSampleDLSOffsets; // in bytes
+    EAS_U32* pSampleDLSLens; // in bytes
+    EAS_SAMPLE* pSampleDLS;
+    struct S_SF2_SAMPLE {
+        EAS_I16 staticTuning;
+        EAS_U8 rootKey;
+        // all in samples
+        EAS_U32 start;
+        EAS_U32 end; // past the end
+        EAS_U32 loopStart;
+        EAS_U32 loopEnd; // past the end
+        EAS_U16 sampleType;
+    }* pShdrs;
+
+    EAS_I32 phdrOffset;
+    EAS_I32 pbagOffset;
+    EAS_U32 pbagCount; // exclude terminal entry
+    EAS_I32 pmodOffset;
+    EAS_I32 pgenOffset;
+
+    EAS_I32 instOffset;
+    EAS_I32 ibagOffset;
+    EAS_U32 ibagCount; // exclude terminal entry
+    EAS_I32 imodOffset;
+    EAS_I32 igenOffset;
+
+    EAS_I32 shdrOffest;
+
+    struct S_SF2_INST {
+        EAS_U16 regionIndex;
+        EAS_U16 regionCount;
+        EAS_U32* pSharedArticulationIndices; // multiple preset can have one instrument without pmod or pgen, so its articulations could be shared
+                                             // size of this array is regionCount
+    } * pInsts;
+    EAS_U32 instCount;
+
+    struct S_SF2_REGION {
+        EAS_U32 genOffset; // relative to igen or pgen offset
+        EAS_U16 genCount;
+        EAS_U32 modOffset; // relative to imod or pmod offset
+        EAS_U16 modCount;
+        EAS_BOOL isGlobal;
+        EAS_U8 keyLow;
+        EAS_U8 keyHigh;
+        EAS_U8 velLow;
+        EAS_U8 velHigh;
+        EAS_U16 waveIndex; // it could point to an instrument or sample
+    } * pInstRegions;
+    EAS_U32 instRegionCount;
+    EAS_U32 instRegionWritten; // used in parsing ibags
+
+    S_PROGRAM* pPresets;
+    S_DLS_REGION* pPresetRegions;
+    S_DLS_ARTICULATION* pPresetArticulations;
+    EAS_U32 presetCount;
+    EAS_U32 presetRegionCount;
+    EAS_U32 presetRegionWritten;
+    EAS_U32 presetArticulationCount;
+    EAS_U32 presetArticulationWritten;
+} S_SF2_PARSER;
+
+const EAS_U16 defaultGenerators[sfg_endOper] = {
+    0,    // startAddrsOffset
+    0,    // endAddrsOffset
+    0,    // startloopAddrsOffset
+    0,    // endloopAddrsOffset
+    0,    // startAddrsCoarseOffset
+    0,    // modLfoToPitch
+    0,    // vibLfoToPitch
+    0,    // modEnvToPitch
+    13500,    // initialFilterFc
+    0,    // initialFilterQ
+    0,    // modLfoToFilterFc
+    0,    // modEnvToFilterFc
+    0,    // endAddrsCoarseOffset
+    0,    // modLfoToVolume
+    0,    // unused1
+    0,    // chorusEffectsSend
+    0,    // reverbEffectsSend
+    0,    // pan
+    0,    // unused2
+    0,    // unused3
+    0,    // unused4
+    -12000,    // delayModLFO
+    0,    // freqModLFO
+    -12000,    // delayVibLFO
+    0,    // freqVibLFO
+    -12000,    // delayModEnv
+    -12000,    // attackModEnv
+    -12000,    // holdModEnv
+    -12000,    // decayModEnv
+    0,    // sustainModEnv
+    -12000,    // releaseModEnv
+    0,    // keynumToModEnvHold
+    0,    // keynumToModEnvDecay
+    -12000,    // delayVolEnv
+    -12000,    // attackVolEnv
+    -12000,    // holdVolEnv
+    -12000,    // decayVolEnv
+    0,    // sustainVolEnv
+    -12000,    // releaseVolEnv
+    0,    // keynumToVolEnvHold
+    0,    // keynumToVolEnvDecay
+    -1,   // instrument
+    0,    // reserved1
+    0x7F00,    // keyRange
+    0x7F00,    // velRange
+    0,    // startloopAddrsCoarseOffset
+    -1,    // keynum
+    -1,    // velocity
+    0,    // initialAttenuation
+    0,   // reserved2
+    0,    // endloopAddrsCoarseOffset
+    0,    // coarseTune
+    0,    // fineTune
+    -1,   // sampleID
+    0,    // sampleModes
+    0,    // reserved3
+    100,    // scaleTuning
+    0,    // exclusiveClass
+    -1,    // overridingRootKey
+    0    // unused5
+};
+
+// pNextChunkPos must point to the first chunk when reading it
+static EAS_RESULT RIFFNextChunk(S_SF2_PARSER* pParser, EAS_U32* pChunkType, EAS_U32* pChunkSize, EAS_I32* pNextChunkPos)
+{
+    EAS_RESULT result;
+
+    result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, *pNextChunkPos);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+    
+    result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, pChunkType, EAS_TRUE);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+
+    result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, pChunkSize, EAS_FALSE);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+
+    *pNextChunkPos += 8;
+    *pNextChunkPos += *pChunkSize;
+
+    // Adjust to word boundary
+    if (*pNextChunkPos % 2 != 0) {
+        (*pNextChunkPos)++;
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_sdta(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 size);
+static EAS_RESULT Parse_pdta(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 size);
+
+static EAS_RESULT Parse_shdrs(S_SF2_PARSER* pParser, EAS_BOOL dryRun);
+
+static EAS_RESULT Parse_samples(S_SF2_PARSER* pParser, EAS_BOOL dryRun);
+
+// offset is file offset to the first bag record
+static EAS_RESULT Parse_ibags(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 bagCount);
+static EAS_RESULT Parse_pbags(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 bagCount, EAS_BOOL dryRun);
+
+static EAS_RESULT Parse_region(S_SF2_PARSER* pParser, struct S_SF2_REGION* pRegion, EAS_I32 genChunkOffset);
+
+static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOper], void* pMods, EAS_U32 modCount, S_DLS_ARTICULATION* pDLSArt, S_DLS_REGION* pDLSRegion, EAS_U8* loopMode);
+
+static EAS_RESULT Parse_Insts(S_SF2_PARSER* pParser, EAS_BOOL dryRun);
+static EAS_RESULT Parse_Presets(S_SF2_PARSER* pParser, EAS_BOOL dryRun);
+
+static inline EAS_RESULT Check_gen(EAS_U16 genType, EAS_BOOL isInst)
+{
+    if (isInst) { // igen
+        if (genType == sfg_instrument) {
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Found preset-only generator type %u at igen entry\n", genType);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+    } else { // pgen
+        switch (genType) {
+        case sfg_startAddrsOffset:
+        case sfg_endAddrsOffset:
+        case sfg_startloopAddrsOffset:
+        case sfg_endloopAddrsOffset:
+        case sfg_startAddrsCoarseOffset:
+        case sfg_endAddrsCoarseOffset:
+        case sfg_startloopAddrsCoarseOffset:
+        case sfg_keynum:
+        case sfg_velocity:
+        case sfg_endloopAddrsCoarseOffset:
+        case sfg_sampleID:
+        case sfg_sampleModes:
+        case sfg_exclusiveClass:
+        case sfg_overridingRootKey:
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Found inst-only generator type %u at pgen entry\n", genType);
+            return EAS_ERROR_FILE_FORMAT;
+        default:
+            break;
+        }
+    }
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT SF2Parser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle, EAS_I32 offset, S_DLS **ppDLS)
+{
+    S_SF2_PARSER parser;
+    EAS_RESULT result;
+    memset(&parser, 0, sizeof(S_SF2_PARSER));
+
+    *ppDLS = NULL;
+
+    parser.hwInstData = hwInstData;
+    parser.fileHandle = fileHandle;
+    parser.fileOffset = offset;
+
+    EAS_I32 nextChunkPos = offset;
+    EAS_U32 temp;
+
+    result = RIFFNextChunk(&parser, &temp, &parser.fileSize, &nextChunkPos);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+    parser.fileSize += 8; // include RIFF header size
+    if (temp != RIFF_IDENTIFIER) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Not a RIFF file (%08x)\n", temp);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    result = EAS_HWGetDWord(parser.hwInstData, parser.fileHandle, &temp, EAS_TRUE);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+    if (temp != SFBK_IDENTIFIER) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Not a SoundFont file (%08x)\n", temp);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    // Read chunks
+    nextChunkPos = offset + 12; // RIFF <size> sfbk
+    while (1) {
+        if (parser.fileOffset + parser.fileSize - nextChunkPos <= 1)  {
+            break; // end of file
+        }
+
+        EAS_U32 chunkType, chunkSize;
+        result = RIFFNextChunk(&parser, &chunkType, &chunkSize, &nextChunkPos);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+
+        EAS_I32 curpos;
+        result = EAS_HWFilePos(parser.hwInstData, parser.fileHandle, &curpos);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+
+        if ((EAS_U32)curpos >= parser.fileOffset + parser.fileSize) {
+            break; // end of file
+        }
+
+        switch (chunkType) {
+        case LIST_IDENTIFIER:
+            result = EAS_HWGetDWord(parser.hwInstData, parser.fileHandle, &temp, EAS_TRUE);
+            if (result != EAS_SUCCESS) {
+                return result;
+            }
+            switch (temp) {
+            case INFO_IDENTIFIER:
+                break;
+            case SDTA_IDENTIFIER:
+                result = Parse_sdta(&parser, curpos, chunkSize);
+                if (result != EAS_SUCCESS) {
+                    EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse sdta LIST chunk: %ld\n", result);
+                    return result;
+                }
+                break;
+            case PDTA_IDENTIFIER:
+                result = Parse_pdta(&parser, curpos, chunkSize);
+                if (result != EAS_SUCCESS) {
+                    EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse pdta LIST chunk: %ld\n", result);
+                    return result;
+                }
+                break;
+            default:
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Unknown LIST chunk type %08x\n", temp);
+                break;
+            }
+            break;
+        default:
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Unknown chunk type %08x\n", chunkType);
+            break;
+        }
+    }
+
+    // stage 1: instrument level, dry run
+    if (parser.shdrOffest == 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: No shdr chunk found in pdta LIST\n");
+        return EAS_ERROR_FILE_FORMAT;
+    }
+    // get sample count and sample data size in S_DLS
+    result = Parse_shdrs(&parser, EAS_TRUE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse shdrs (dry): %ld\n", result);
+        return result;
+    }
+
+    if (parser.instOffset == 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: No inst chunk found in pdta LIST\n");
+        return EAS_ERROR_FILE_FORMAT;
+    }
+    // get instrument and regions count
+    result = Parse_Insts(&parser, EAS_TRUE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse insts (dry): %ld\n", result);
+        return result;
+    }
+
+    // stage 2: instrument level, full run
+    // 1. parse shdrs
+    parser.pShdrs = EAS_HWMalloc(parser.hwInstData, sizeof(struct S_SF2_SAMPLE) * parser.sampleCount);
+    if (parser.pShdrs == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for shdr structs (%lu bytes)\n",
+                   (unsigned long)(sizeof(struct S_SF2_SAMPLE) * parser.sampleCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    result = Parse_shdrs(&parser, EAS_FALSE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse shdrs: %ld\n", result);
+        return result;
+    }
+    // 2. parse insts
+    parser.pInsts = EAS_HWMalloc(parser.hwInstData, sizeof(struct S_SF2_INST) * parser.instCount);
+    if (parser.pInsts == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for inst structs (%lu bytes)\n",
+                   (unsigned long)(sizeof(struct S_SF2_INST) * parser.instCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    parser.pInstRegions = EAS_HWMalloc(parser.hwInstData, sizeof(struct S_SF2_REGION) * parser.instRegionCount);
+    if (parser.pInstRegions == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for inst region structs (%lu bytes)\n",
+                   (unsigned long)(sizeof(S_DLS_REGION) * parser.instRegionCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    result = Parse_Insts(&parser, EAS_FALSE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse insts: %ld\n", result);
+        return result;
+    }
+
+    // stage 3: preset level, dry run
+    if (parser.phdrOffset == 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: No phdr found in pdta LIST\n");
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    result = Parse_Presets(&parser, EAS_TRUE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse presets (dry): %ld\n", result);
+        return result;
+    }
+
+    // stage 4: preset level, full run
+    parser.pPresets = EAS_HWMalloc(parser.hwInstData, sizeof(S_PROGRAM) * parser.presetCount);
+    if (parser.pPresets == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for preset program structs (%lu bytes)\n",
+                   (unsigned long)(sizeof(S_PROGRAM) * parser.presetCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    parser.pPresetRegions = EAS_HWMalloc(parser.hwInstData, sizeof(S_DLS_REGION) * parser.presetRegionCount);
+    if (parser.pPresetRegions == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for preset region structs (%lu bytes)\n",
+                   (unsigned long)(sizeof(S_DLS_REGION) * parser.presetRegionCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    parser.pPresetArticulations = EAS_HWMalloc(parser.hwInstData, sizeof(S_DLS_ARTICULATION) * parser.presetArticulationCount);
+    if (parser.pPresetArticulations == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for preset articulation structs (%lu bytes)\n",
+                   (unsigned long)(sizeof(S_DLS_ARTICULATION) * parser.presetArticulationCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    result = Parse_Presets(&parser, EAS_FALSE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse presets: %ld\n", result);
+        return result;
+    }
+
+    // stage 5: samples
+    parser.pSampleDLSOffsets = EAS_HWMalloc(parser.hwInstData, sizeof(EAS_U32) * parser.sampleCount);
+    if (parser.pSampleDLSOffsets == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for sample offsets (%lu bytes)\n",
+                   (unsigned long)(sizeof(EAS_U32) * parser.sampleCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+
+    parser.pSampleDLSLens = EAS_HWMalloc(parser.hwInstData, sizeof(EAS_U32) * parser.sampleCount);
+    if (parser.pSampleDLSLens == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for sample lengths (%lu bytes)\n",
+                   (unsigned long)(sizeof(EAS_U32) * parser.sampleCount));
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+
+    result = Parse_samples(&parser, EAS_TRUE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse samples (dry): %ld\n", result);
+        return result;
+    }
+
+    parser.pSampleDLS = EAS_HWMalloc(parser.hwInstData, parser.sampleDLSSize);
+    if (parser.pSampleDLS == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for sample data (%lu bytes)\n",
+                   (unsigned long)parser.sampleDLSSize);
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+
+    result = Parse_samples(&parser, EAS_FALSE);
+    if (result != EAS_SUCCESS) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse samples: %ld\n", result);
+        return result;
+    }
+
+    // stage 6: copy everything to S_DLS
+    parser.pDLS = EAS_HWMalloc(hwInstData, sizeof(S_DLS));
+    if (parser.pDLS == NULL) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate memory for DLS structure\n");
+        return EAS_ERROR_MALLOC_FAILED;
+    }
+    memset(parser.pDLS, 0, sizeof(S_DLS));
+    parser.pDLS->pDLSPrograms = parser.pPresets;
+    parser.pDLS->pDLSRegions = parser.pPresetRegions;
+    parser.pDLS->pDLSArticulations = parser.pPresetArticulations;
+    parser.pDLS->pDLSSampleLen = parser.pSampleDLSLens;
+    parser.pDLS->pDLSSampleOffsets = parser.pSampleDLSOffsets;
+    parser.pDLS->pDLSSamples = parser.pSampleDLS;
+    parser.pDLS->numDLSPrograms = parser.presetCount;
+    parser.pDLS->numDLSRegions = parser.presetRegionCount;
+    parser.pDLS->numDLSArticulations = parser.presetArticulationCount;
+    parser.pDLS->numDLSSamples = parser.sampleCount;
+    parser.pDLS->refCount = 1;
+    parser.pDLS->libType = DLSLIB_TYPE_SF2;
+
+    *ppDLS = parser.pDLS;
+
+    // stage 7: cleanup
+    EAS_HWFree(hwInstData, parser.pShdrs);
+    EAS_HWFree(hwInstData, parser.pInsts);
+    EAS_HWFree(hwInstData, parser.pInstRegions);
+
+    return EAS_SUCCESS;
+}
+
+EAS_RESULT SF2Cleanup (EAS_HW_DATA_HANDLE hwInstData, S_DLS *pDLS)
+{
+    if (!pDLS) {
+        return EAS_SUCCESS;
+    }
+
+    if (pDLS->libType != DLSLIB_TYPE_SF2) {
+        return EAS_ERROR_DATA_INCONSISTENCY;
+    }
+
+    EAS_HWFree(hwInstData, pDLS->pDLSPrograms);
+    EAS_HWFree(hwInstData, pDLS->pDLSRegions);
+    EAS_HWFree(hwInstData, pDLS->pDLSArticulations);
+    EAS_HWFree(hwInstData, pDLS->pDLSSampleLen);
+    EAS_HWFree(hwInstData, pDLS->pDLSSampleOffsets);
+    EAS_HWFree(hwInstData, pDLS->pDLSSamples);
+    EAS_HWFree(hwInstData, pDLS);
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_sdta(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 size)
+{
+    EAS_RESULT result;
+    EAS_I32 pos = offset + 4; // skip 'sdta' identifier
+    
+    while (1) {
+        if (offset + size - pos <= 1) {
+            break; // end of LIST chunk
+        }
+
+        EAS_U32 chunkType, chunkSize;
+        result = RIFFNextChunk(pParser, &chunkType, &chunkSize, &pos);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+
+        EAS_I32 curpos;
+        result = EAS_HWFilePos(pParser->hwInstData, pParser->fileHandle, &curpos);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        if ((EAS_U32)curpos >= offset + size) {
+            break; // end of LIST chunk
+        }
+
+        switch (chunkType) {
+        case SMPL_IDENTIFIER:
+            if (chunkSize % 2 == 1) {
+                EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: smpl chunk size is not even (%u)\n", chunkSize);
+                return EAS_ERROR_FILE_FORMAT;
+            }
+            pParser->smplOffset = curpos;
+            pParser->smplSize = chunkSize;
+            break;
+        case SM24_IDENTIFIER:
+            // EAS don't support 24 bit samples, throw it away
+            break;
+        default:
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Unknown chunk in sdta LIST: %08x\n", chunkType);
+            break;
+        }
+    }
+
+    if (pParser->smplSize == 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: No smpl chunk found in sdta LIST\n");
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Decode_SF2smpl(S_SF2_PARSER* pParser, struct S_SF2_SAMPLE* pShdr, EAS_U32 writeOffset, EAS_U32* wroteLength, EAS_BOOL dryRun)
+{
+    EAS_RESULT result;
+
+    EAS_U32 nSamples = pShdr->end - pShdr->start; // in samples
+
+    if (pShdr->loopStart >= pShdr->end || pShdr->loopStart < pShdr->start) {
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Invalid loop start %u out of range [%u, %u) of sample %u\n", pShdr->loopStart, pShdr->start, pShdr->end, (unsigned)(pShdr - pParser->pShdrs));
+        pShdr->loopStart = pShdr->start;
+    }
+    if (pShdr->loopEnd > pShdr->end || pShdr->loopEnd <= pShdr->start) {
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Invalid loop end %u out of range [%u, %u) of sample %u\n", pShdr->loopEnd, pShdr->start, pShdr->end, (unsigned)(pShdr - pParser->pShdrs));
+        pShdr->loopEnd = pShdr->end;
+    }
+
+    if (pShdr->loopStart != pShdr->loopEnd) {
+        // reserved for copying *loopStart to 1 beyond loopEnd, see WT_Interpolate
+        nSamples += 1;
+    }
+
+    const EAS_U32 dlsLen = nSamples * sizeof(EAS_SAMPLE);
+    const EAS_U32 dataLen = nSamples * 2;
+
+    if (dryRun) {
+        *wroteLength = dlsLen;
+        return EAS_SUCCESS;
+    }
+    
+    result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->smplOffset + (pShdr->start * 2));
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+
+    EAS_U8 buffer[4096];
+    EAS_U32 remaining = dataLen;
+    EAS_SAMPLE* destination = pParser->pSampleDLS + (writeOffset / sizeof(EAS_SAMPLE));
+    while (remaining > 0) {
+        EAS_U32 c = remaining > sizeof(buffer) ? sizeof(buffer) : remaining;
+        result = EAS_HWReadFile(pParser->hwInstData, pParser->fileHandle, buffer, c, &c);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+#ifdef _16_BIT_SAMPLES
+        memcpy(destination, buffer, c);
+#else
+        for (EAS_U32 j = 0; j < c / 2; j++) {
+            ((EAS_SAMPLE*)destination)[j] = buffer[j * 2 + 1]; // MSB
+        }
+#endif
+        remaining -= c;
+        destination += c / 2;
+    }
+
+    if (pShdr->loopStart != pShdr->loopEnd) {
+        // copy *loopStart to 1 beyond loopEnd, see WT_Interpolate
+        pParser->pSampleDLS[(writeOffset / sizeof(EAS_SAMPLE)) + (pShdr->loopEnd - pShdr->start)] = pParser->pSampleDLS[(writeOffset / sizeof(EAS_SAMPLE)) + (pShdr->loopStart - pShdr->start)];
+    }
+
+    *wroteLength = dlsLen;
+    return result;
+}
+
+static EAS_RESULT Parse_samples(S_SF2_PARSER* pParser, EAS_BOOL dryRun)
+{
+    EAS_RESULT result;
+
+    if (dryRun) {
+        pParser->sampleDLSSize = 0;
+    }
+    pParser->sampleDLSWritten = 0;
+
+    for (EAS_U32 i = 0; i < pParser->sampleCount; i++) {
+        struct S_SF2_SAMPLE* pShdr = &pParser->pShdrs[i];
+
+        EAS_U32 dlsLen = 0;
+
+        pParser->pSampleDLSOffsets[i] = pParser->sampleDLSWritten;
+
+        if (pShdr->sampleType & SAMPLETYPE_COMPRESSED) {
+            // only vorbis is supported now
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Compressed sample data is not supported (sample %u)\n", (unsigned)i);
+            return EAS_ERROR_FEATURE_NOT_AVAILABLE;
+        }
+        result = Decode_SF2smpl(pParser, pShdr, pParser->pSampleDLSOffsets[i], &dlsLen, dryRun);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pSampleDLSLens[i] = dlsLen;
+        if (dryRun) {
+            pParser->sampleDLSSize += dlsLen;
+        } else {
+            pParser->sampleDLSWritten += dlsLen;
+        }
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_pdta(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 size)
+{
+    EAS_RESULT result;
+    EAS_I32 pos = offset + 4; // skip 'pdta' identifier
+
+    while (1) {
+        if (offset + size - pos <= 1) {
+            break; // end of LIST chunk
+        }
+
+        EAS_U32 chunkType, chunkSize;
+        result = RIFFNextChunk(pParser, &chunkType, &chunkSize, &pos);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+
+        EAS_I32 curpos;
+        result = EAS_HWFilePos(pParser->hwInstData, pParser->fileHandle, &curpos);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        if ((EAS_U32)curpos >= offset + size) {
+            break; // end of LIST chunk
+        }
+
+        switch (chunkType) {
+        case PHDR_IDENTIFIER:
+            pParser->phdrOffset = curpos - 8; // at the start of the chunk ('phdr' identifier)
+            break;
+        case PBAG_IDENTIFIER:
+            pParser->pbagOffset = curpos - 8;
+            pParser->pbagCount = (chunkSize / PBAG_SIZE) - 1;
+            break;
+        case PMOD_IDENTIFIER:
+            pParser->pmodOffset = curpos - 8;
+            break;
+        case PGEN_IDENTIFIER:
+            pParser->pgenOffset = curpos - 8;
+            break;
+        case INST_IDENTIFIER:
+            pParser->instOffset = curpos - 8;
+            break;
+        case IBAG_IDENTIFIER:
+            pParser->ibagOffset = curpos - 8;
+            pParser->ibagCount = (chunkSize / IBAG_SIZE) - 1;
+            break;
+        case IMOD_IDENTIFIER:
+            pParser->imodOffset = curpos - 8;
+            break;
+        case IGEN_IDENTIFIER:
+            pParser->igenOffset = curpos - 8;
+            break;
+        case SHDR_IDENTIFIER:
+            pParser->shdrOffest = curpos - 8;
+            break;
+        default:
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Unknown chunk in pdta at 0x%lx: 0x%08x\n", (long)curpos, chunkType);
+            break;
+        }
+    }
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_shdrs(S_SF2_PARSER* pParser, EAS_BOOL dryRun) {
+    EAS_RESULT result;
+    EAS_I32 pos = pParser->shdrOffest;
+
+    EAS_U32 tmp, chunkSize;
+    result = RIFFNextChunk(pParser, &tmp, &chunkSize, &pos);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+    if (tmp != SHDR_IDENTIFIER) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Expected 'shdr' chunk, got 0x%08x\n", tmp);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+    if (chunkSize % SHDR_SIZE != 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Invalid SHDR chunk size %u\n", chunkSize);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    pParser->sampleCount = chunkSize / SHDR_SIZE - 1; // exclude EOS
+    if (dryRun) {
+        return EAS_SUCCESS;
+    }
+
+    for (EAS_U32 i = 0; i < pParser->sampleCount; i++) {
+        // skip sample name
+        result = EAS_HWFileSeekOfs(pParser->hwInstData, pParser->fileHandle, 20);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, &tmp, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].start = tmp;
+        result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, &tmp, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].end = tmp;
+        result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, &tmp, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].loopStart = tmp;
+        result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, &tmp, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].loopEnd = tmp;
+        result = EAS_HWGetDWord(pParser->hwInstData, pParser->fileHandle, &tmp, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].staticTuning = DLSConvertSampleRate(tmp);
+
+        EAS_U8 tmp2;
+        result = EAS_HWGetByte(pParser->hwInstData, pParser->fileHandle, &tmp2);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].rootKey = tmp2;
+        result = EAS_HWGetByte(pParser->hwInstData, pParser->fileHandle, &tmp2);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].staticTuning += (EAS_I8)tmp2;
+        // skip sample link
+        result = EAS_HWFileSeekOfs(pParser->hwInstData, pParser->fileHandle, 2);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        EAS_U16 sampleType;
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &sampleType, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        pParser->pShdrs[i].sampleType = sampleType;
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_Insts(S_SF2_PARSER* pParser, EAS_BOOL dryRun)
+{
+    EAS_RESULT result;
+    EAS_I32 pos = pParser->instOffset;
+
+    EAS_U32 tmp, chunkSize;
+    result = RIFFNextChunk(pParser, &tmp, &chunkSize, &pos);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+    if (tmp != INST_IDENTIFIER) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Expected 'inst' chunk, got %08x\n", tmp);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+    if (chunkSize % INST_SIZE != 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Invalid inst chunk size %u\n", chunkSize);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    pParser->instCount = chunkSize / INST_SIZE - 1; // exclude the 'EOI' entry
+    if (dryRun) {
+        pParser->instRegionCount = 0;
+    }
+    pParser->instRegionWritten = 0;
+
+    EAS_U16 bagIndex;
+    EAS_U16 prevBagIndex = 0;
+    for (EAS_U32 i = 0; i < pParser->instCount + 1; i++) {
+        const long offset = pParser->instOffset + 8 + (INST_SIZE * i);
+        // skip inst name
+        result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, offset + 20);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &bagIndex, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        if (i == 0) {
+            goto skip;
+        }
+        if (i == pParser->instCount) {
+            // EOI's bagIndex is 0
+            bagIndex = pParser->ibagCount;
+        }
+
+        if (bagIndex == prevBagIndex) {
+            // empty inst
+            goto skip;
+        }
+        if (bagIndex < prevBagIndex) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Non monotonic bag index %u at inst entry at 0x%lx\n", bagIndex, offset);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+        
+        if (dryRun) {
+            pParser->instRegionCount += bagIndex - prevBagIndex;
+            goto skip;
+        }
+
+        pParser->pInsts[i - 1].regionIndex = pParser->instRegionWritten;
+        pParser->pInsts[i - 1].regionCount = bagIndex - prevBagIndex;
+
+        result = Parse_ibags(pParser, pParser->ibagOffset + 8 + (prevBagIndex * IBAG_SIZE), bagIndex - prevBagIndex);
+        if (result != EAS_SUCCESS) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse bags of inst entry at 0x%lx: %ld\n", offset - INST_SIZE, result);
+            return result;
+        }
+    skip:
+        prevBagIndex = bagIndex;
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_region(S_SF2_PARSER* pParser, struct S_SF2_REGION* pRegion, EAS_I32 genChunkOffset)
+{
+    EAS_RESULT result;
+    pRegion->velLow = 0;
+    pRegion->velHigh = 127;
+    pRegion->keyLow = 0;
+    pRegion->keyHigh = 127;
+    pRegion->isGlobal = EAS_TRUE;
+
+    for (EAS_U32 j = 0; j < pRegion->genCount; j++) {
+        result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, genChunkOffset + pRegion->genOffset + (j * GEN_SIZE));
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        EAS_U16 genType, genValue;
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genType, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genValue, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        // genValue is read as LE
+        if (genType == sfg_keyRange) {
+            // some weird sf2 specify keyrange on global regions
+            // pRegion->isGlobal = EAS_FALSE;
+            pRegion->keyLow = (EAS_U8)(genValue & 0xFF);
+            pRegion->keyHigh = (EAS_U8)((genValue >> 8) & 0xFF);
+        } else if (genType == sfg_velRange) {
+            // pRegion->isGlobal = EAS_FALSE;
+            pRegion->velLow = (EAS_U8)(genValue & 0xFF);
+            pRegion->velHigh = (EAS_U8)((genValue >> 8) & 0xFF);
+        } else if (genType == sfg_instrument) {
+            pRegion->isGlobal = EAS_FALSE;
+            pRegion->waveIndex = genValue;
+        } else if (genType == sfg_sampleID) {
+            pRegion->isGlobal = EAS_FALSE;
+            pRegion->waveIndex = genValue;
+        }
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_ibags(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 bagCount)
+{
+    EAS_RESULT result;
+
+    if (bagCount == 0) {
+        return EAS_SUCCESS; // no bags to parse
+    }
+
+    EAS_U16 genIndex, prevGenIndex = 0;
+    EAS_U16 modIndex, prevModIndex = 0;
+    for (EAS_U32 i = 0; i < bagCount + 1; i++) {
+        const long myoffset = offset + (i * IBAG_SIZE);
+        result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, myoffset);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genIndex, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modIndex, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        if (i == 0) {
+            goto skip;
+        }
+
+        if (genIndex < prevGenIndex) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Non monotonic generator index %u at ibag entry at 0x%lx\n", genIndex, myoffset);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+        if (modIndex < prevModIndex) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Non monotonic modulator index %u at ibag entry at 0x%lx\n", modIndex, myoffset);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+
+        EAS_U32 regionIndex = pParser->instRegionWritten;
+
+        pParser->pInstRegions[regionIndex].genOffset = 8 + (prevGenIndex * GEN_SIZE);
+        pParser->pInstRegions[regionIndex].modOffset = 8 + (prevModIndex * MOD_SIZE);
+        pParser->pInstRegions[regionIndex].genCount = genIndex - prevGenIndex;
+        pParser->pInstRegions[regionIndex].modCount = modIndex - prevModIndex;
+
+        result = Parse_region(pParser, &pParser->pInstRegions[regionIndex], pParser->igenOffset);
+        if (result != EAS_SUCCESS) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to ibag entry at 0x%lx: %ld\n", myoffset - IBAG_SIZE, result);
+            return result;
+        }
+        pParser->instRegionWritten++;
+    skip:
+        prevGenIndex = genIndex;
+        prevModIndex = modIndex;
+    }
+
+    return EAS_SUCCESS;
+}
+
+static EAS_RESULT Parse_Presets(S_SF2_PARSER* pParser, EAS_BOOL dryRun)
+{
+    EAS_RESULT result;
+    EAS_I32 pos = pParser->phdrOffset;
+
+    EAS_U32 tmp, chunkSize;
+    result = RIFFNextChunk(pParser, &tmp, &chunkSize, &pos);
+    if (result != EAS_SUCCESS) {
+        return result;
+    }
+    if (tmp != PHDR_IDENTIFIER) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Expected 'phdr' chunk, got %08x\n", tmp);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+    if (chunkSize % PHDR_SIZE != 0) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Invalid phdr chunk size %u\n", chunkSize);
+        return EAS_ERROR_FILE_FORMAT;
+    }
+
+    pParser->presetCount = chunkSize / PHDR_SIZE - 1; // exclude the 'EOP' entry
+    if (dryRun) {
+        pParser->presetRegionCount = 0;
+        pParser->presetArticulationCount = 0;
+    }
+    pParser->presetRegionWritten = 0;
+    pParser->presetArticulationWritten = 0;
+
+    EAS_U16 bagIndex, prevBagIndex = 0;
+    for (EAS_U32 i = 0; i < pParser->presetCount + 1; i++) {
+        const long offset = pParser->phdrOffset + 8 + (PHDR_SIZE * i);
+        // skip inst name
+        result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, offset + 20);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+
+        EAS_U16 presetID, bankID;
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &presetID, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &bankID, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+
+        if (bankID > 128) {
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Invalid bankID %u at phdr entry at 0x%lx, ignoring\n", bankID, offset);
+            bankID = 0xFF;
+        }
+
+        if (bankID == 128) {
+            bankID = DEFAULT_RHYTHM_BANK_MSB | 0x100; // rhythm flag
+        }
+
+        if (presetID > 128) {
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Invalid presetID %u at phdr entry at 0x%lx, ignoring\n", presetID, offset);
+            presetID = 0xFF;
+        }
+
+        if (!dryRun && i != pParser->presetCount) {
+            pParser->pPresets[i].locale = (bankID << 16) | presetID;
+        }
+
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &bagIndex, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        if (i == 0) {
+            goto skip;
+        }
+        if (i == pParser->presetCount) {
+            // EOP's bagIndex is 0
+            bagIndex = pParser->pbagCount;
+        }
+        if (bagIndex == prevBagIndex) {
+            // empty inst
+            goto skip;
+        }
+
+        if (bagIndex < prevBagIndex) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Non monotonic bag index %u at phdr entry at 0x%lx\n", bagIndex, offset);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+
+        EAS_U32 regionIndex = pParser->presetRegionWritten;
+        result = Parse_pbags(pParser, pParser->pbagOffset + 8 + (prevBagIndex * 4), bagIndex - prevBagIndex, dryRun);
+        if (result != EAS_SUCCESS) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse pbags at entry at 0x%lx: %ld\n", offset - PHDR_SIZE, result);
+            return result;
+        }
+
+        if (!dryRun) {
+            if (pParser->presetRegionWritten == regionIndex) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Preset %u has no regions\n", i - 1);
+                pParser->pPresets[i - 1].regionIndex = INVALID_REGION_INDEX;
+                goto skip;
+            }
+            EAS_U32 regionLast = pParser->presetRegionWritten - 1;
+            pParser->pPresets[i - 1].regionIndex = regionIndex | FLAG_RGN_IDX_DLS_SYNTH;
+            pParser->pPresetRegions[regionLast].wtRegion.region.keyGroupAndFlags |= REGION_FLAG_LAST_REGION;
+        }
+    skip:
+        prevBagIndex = bagIndex;
+    }
+
+    if (dryRun) {
+        return EAS_SUCCESS;
+    }
+
+    if (pParser->presetArticulationWritten != pParser->presetArticulationCount) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: written articulation count %u does not match calculated count %u\n", pParser->presetArticulationWritten, pParser->presetArticulationCount);
+        return EAS_ERROR_DATA_INCONSISTENCY;
+    }
+
+    if (pParser->presetRegionWritten != pParser->presetRegionCount) {
+        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: written region count %u does not match calculated count %u\n", pParser->presetRegionWritten, pParser->presetRegionCount);
+        return EAS_ERROR_DATA_INCONSISTENCY;
+    }
+
+    return EAS_SUCCESS;
+}
+
+inline static EAS_BOOL IsValueGenerator(EAS_U16 gen) {
+    return (gen >= 5 && gen != 12 && gen <= 13)
+        || (gen >= 15 && gen <= 17)
+        || (gen >= 21 && gen <= 40)
+        || (gen == 48)
+        || (gen == 51)
+        || (gen == 52);
+}
+
+static EAS_RESULT Parse_pbags(S_SF2_PARSER* pParser, EAS_I32 offset, EAS_U32 bagCount, EAS_BOOL dryRun)
+{
+    EAS_RESULT result;
+
+    if (bagCount == 0) {
+        return EAS_SUCCESS; // no bags to parse
+    }
+
+    // isGlobal is used to check if global region exists
+    struct S_SF2_REGION presetGlobalRegion = {0, 0, 0, 0, EAS_FALSE, 0, 0, 0, 0};
+
+    EAS_U16 genIndex, prevGenIndex = 0;
+    EAS_U16 modIndex, prevModIndex = 0;
+    for (EAS_U32 i = 0; i < bagCount + 1; i++) {
+        const long myOffset = offset + (i * PBAG_SIZE);
+        result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, myOffset);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genIndex, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modIndex, EAS_FALSE);
+        if (result != EAS_SUCCESS) {
+            return result;
+        }
+        if (i == 0) {
+            goto skip;
+        }
+
+        if (genIndex < prevGenIndex) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Non monotonic generator index %u at ibag entry at %lu\n", genIndex, myOffset);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+        if (modIndex < prevModIndex) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Non monotonic modulator index %u at ibag entry at %lu\n", modIndex, myOffset);
+            return EAS_ERROR_FILE_FORMAT;
+        }
+
+        // this is parsing region (i-1) now
+
+        struct S_SF2_REGION presetRegion;
+        presetRegion.genOffset = 8 + (prevGenIndex * GEN_SIZE);
+        presetRegion.modOffset = 8 + (prevModIndex * MOD_SIZE);
+        presetRegion.genCount = genIndex - prevGenIndex;
+        presetRegion.modCount = modIndex - prevModIndex;
+
+        result = Parse_region(pParser, &presetRegion, pParser->pgenOffset);
+        if (result != EAS_SUCCESS) {
+            EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse pbag at entry %u: %ld\n", i - 1, result);
+            return result;
+        }
+
+        if (presetRegion.isGlobal) {
+            presetGlobalRegion = presetRegion;
+            goto skip;
+        }
+
+        // merge preset's global region and current region, inst's global region and matching regions
+        struct S_SF2_INST* pInst = &pParser->pInsts[presetRegion.waveIndex];
+        struct S_SF2_REGION* pInstGlobalRegion = NULL;
+        for (EAS_U32 instRegionIndex = 0; instRegionIndex < pInst->regionCount; instRegionIndex++) {
+            struct S_SF2_REGION* pInstRegion = &pParser->pInstRegions[pInst->regionIndex + instRegionIndex];
+            if (pInstRegion->isGlobal) {
+                pInstGlobalRegion = pInstRegion;
+                continue;
+            }
+
+            EAS_U8 keyL = max(presetRegion.keyLow, pInstRegion->keyLow);
+            EAS_U8 keyH = min(presetRegion.keyHigh, pInstRegion->keyHigh);
+            if (keyL > keyH) {
+                continue; // no overlap
+            }
+            EAS_U8 velL = max(presetRegion.velLow, pInstRegion->velLow);
+            EAS_U8 velH = min(presetRegion.velHigh, pInstRegion->velHigh);
+            if (velL > velH) {
+                continue; // no overlap
+            }
+
+            // whether a new articulation should be created for this region
+            EAS_BOOL createArticulation = presetRegion.modCount > 0 || presetRegion.genCount > 0 || presetGlobalRegion.isGlobal;
+            // whether to share the newly created articulation
+            EAS_BOOL shareArticulation = EAS_FALSE;
+            if (!createArticulation) {
+                if (pInst->pSharedArticulationIndices == NULL) {
+                    pInst->pSharedArticulationIndices = EAS_HWMalloc(pParser->hwInstData, sizeof(EAS_U32) * pInst->regionCount);
+                    if (pInst->pSharedArticulationIndices == NULL) {
+                        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to allocate shared articulation indices for inst %u\n", presetRegion.waveIndex);
+                        return EAS_ERROR_MALLOC_FAILED;
+                    }
+                    memset(pInst->pSharedArticulationIndices, 0xFF, sizeof(EAS_U32) * pInst->regionCount);
+                }
+                if (pInst->pSharedArticulationIndices[instRegionIndex] == 0xFFFFFFFF) {
+                    createArticulation = EAS_TRUE;
+                    shareArticulation = EAS_TRUE;
+                }
+            }
+
+            if (dryRun) {
+                pParser->presetRegionCount++;
+                if (createArticulation) {
+                    pParser->presetArticulationCount++;
+                }
+                continue;
+            }
+
+            struct s_mod {
+                EAS_U16 src;
+                EAS_U16 dest;
+                EAS_U16 amount;
+                EAS_U16 amountSrc;
+                EAS_U16 transform;
+            } mods[MAX_MODS_IN_MERGED_REGION];
+            EAS_U32 modCount = 6;
+            EAS_I16 gens[sfg_endOper];
+            memcpy(gens, defaultGenerators, sizeof(defaultGenerators));
+
+            // default modulators
+            // note-on vel to attenuation
+            mods[0].src = 0x0502;
+            mods[0].dest = sfg_initialAttenuation;
+            mods[0].amount = 960;
+            mods[0].amountSrc = 0;
+            mods[0].transform = 0;
+
+            // note-on vel to filter cutoff
+            mods[1].src = 0x0102;
+            mods[1].dest = sfg_initialFilterFc;
+            mods[1].amount = -2400;
+            mods[1].amountSrc = 0;
+            mods[1].transform = 0;
+
+            // channel pressure to vib lfo pitch depth
+            mods[2].src = 0x000D;
+            mods[2].dest = sfg_vibLfoToPitch;
+            mods[2].amount = 50;
+            mods[2].amountSrc = 0;
+            mods[2].transform = 0;
+
+            // cc1 to vib lfo pitch depth
+            mods[3].src = 0x0081;
+            mods[3].dest = sfg_vibLfoToPitch;
+            mods[3].amount = 50;
+            mods[3].amountSrc = 0;
+            mods[3].transform = 0;
+
+            // cc91 to reverb send
+            mods[4].src = 0x00DB;
+            mods[4].dest = sfg_reverbEffectsSend;
+            mods[4].amount = 200;
+            mods[4].amountSrc = 0;
+            mods[4].transform = 0;
+
+            // cc93 to chorus send
+            mods[5].src = 0x00DD;
+            mods[5].dest = sfg_chorusEffectsSend;
+            mods[5].amount = 200;
+            mods[5].amountSrc = 0;
+            mods[5].transform = 0;
+
+            // N.B. this is ordered, latter will overwrite former
+            // apply inst global
+            if (pInstGlobalRegion != NULL) {
+                for (EAS_U32 k = 0; k < pInstGlobalRegion->genCount; k++) {
+                    EAS_U16 genType;
+                    EAS_I16 genValue;
+                    result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->igenOffset + pInstGlobalRegion->genOffset + (k * GEN_SIZE));
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genType, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genValue, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = Check_gen(genType, EAS_TRUE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    gens[genType] = genValue;
+                }
+
+                for (EAS_U32 k = 0; k < pInstGlobalRegion->modCount; k++) {
+                    if (modCount >= MAX_MODS_IN_MERGED_REGION) {
+                        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: too many modulators in merged preset %u region %u\n", i - 1, instRegionIndex);
+                        return EAS_ERROR_SOUND_LIBRARY;
+                    }
+                    EAS_U16 modSrc;
+                    EAS_U16 modDest;
+                    EAS_U16 modAmount;
+                    EAS_U16 modAmountSrc;
+                    EAS_U16 modTransform;
+                    result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->imodOffset + pInstGlobalRegion->modOffset + (k * MOD_SIZE));
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modSrc, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modDest, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmount, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmountSrc, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modTransform, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+
+                    for (EAS_U32 l = 0; l < modCount; l++) {
+                        if (mods[l].src == modSrc && mods[l].dest == modDest && mods[l].amountSrc == modAmountSrc && mods[l].transform == modTransform) {
+                            mods[l].amount = modAmount;
+                            goto foundoverride;
+                        }
+                    }
+                    mods[modCount].src = modSrc;
+                    mods[modCount].dest = modDest;
+                    mods[modCount].amount = modAmount;
+                    mods[modCount].amountSrc = modAmountSrc;
+                    mods[modCount].transform = modTransform;
+                    modCount++;
+                foundoverride:;
+                }
+            }
+
+            // apply inst region
+            // this should add sampleID
+            EAS_BOOL foundSampleID = EAS_FALSE;
+            EAS_U16 sampleID;
+            for (EAS_U32 k = 0; k < pInstRegion->genCount; k++) {
+                EAS_U16 genType;
+                EAS_I16 genValue;
+                result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->igenOffset + pInstRegion->genOffset + (k * GEN_SIZE));
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genType, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genValue, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                if (genType == sfg_keyRange || genType == sfg_velRange) {
+                    continue;
+                }
+                if (genType == sfg_sampleID) {
+                    foundSampleID = EAS_TRUE;
+                    sampleID = genValue;
+                    continue;
+                }
+                result = Check_gen(genType, EAS_TRUE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                gens[genType] = genValue;
+            }
+
+            if (!foundSampleID) {
+                EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Inst %u region %u does not contain sampleID\n", presetRegion.waveIndex, instRegionIndex);
+                return EAS_FAILURE;
+            }
+
+            for (EAS_U32 k = 0; k < pInstRegion->modCount; k++) {
+                if (modCount >= MAX_MODS_IN_MERGED_REGION) {
+                    EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: too many modulators in merged preset %u region %u\n", i - 1, instRegionIndex);
+                    return EAS_ERROR_SOUND_LIBRARY;
+                }
+                EAS_U16 modSrc;
+                EAS_U16 modDest;
+                EAS_U16 modAmount;
+                EAS_U16 modAmountSrc;
+                EAS_U16 modTransform;
+                result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->imodOffset + pInstRegion->modOffset + (k * MOD_SIZE));
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modSrc, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modDest, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmount, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmountSrc, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modTransform, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+
+                for (EAS_U32 l = 0; l < modCount; l++) {
+                    if (mods[l].src == modSrc && mods[l].dest == modDest && mods[l].amountSrc == modAmountSrc && mods[l].transform == modTransform) {
+                        mods[l].amount = modAmount;
+                        goto foundoverride2;
+                    }
+                }
+                mods[modCount].src = modSrc;
+                mods[modCount].dest = modDest;
+                mods[modCount].amount = modAmount;
+                mods[modCount].amountSrc = modAmountSrc;
+                mods[modCount].transform = modTransform;
+                modCount++;
+            foundoverride2:;
+            }
+
+            // apply preset global
+            if (presetGlobalRegion.isGlobal) {
+                for (EAS_U32 k = 0; k < presetGlobalRegion.genCount; k++) {
+                    EAS_U16 genType;
+                    EAS_I16 genValue;
+                    result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->pgenOffset + presetGlobalRegion.genOffset + (k * GEN_SIZE));
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genType, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genValue, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = Check_gen(genType, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    if (IsValueGenerator(genType)) {
+                        gens[genType] += genValue;
+                    } else {
+                        gens[genType] = genValue;
+                    }
+                }
+
+                for (EAS_U32 k = 0; k < presetGlobalRegion.modCount; k++) {
+                    if (modCount >= MAX_MODS_IN_MERGED_REGION) {
+                        EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: too many modulators in merged preset %u region %u\n", i - 1, instRegionIndex);
+                        return EAS_ERROR_SOUND_LIBRARY;
+                    }
+                    EAS_U16 modSrc;
+                    EAS_U16 modDest;
+                    EAS_U16 modAmount;
+                    EAS_U16 modAmountSrc;
+                    EAS_U16 modTransform;
+                    result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->pmodOffset + presetGlobalRegion.modOffset + (k * MOD_SIZE));
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modSrc, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modDest, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmount, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmountSrc, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+                    result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modTransform, EAS_FALSE);
+                    if (result != EAS_SUCCESS) {
+                        return result;
+                    }
+
+                    mods[modCount].src = modSrc;
+                    mods[modCount].dest = modDest;
+                    mods[modCount].amount = modAmount;
+                    mods[modCount].amountSrc = modAmountSrc;
+                    mods[modCount].transform = modTransform;
+                    modCount++;
+                }
+            }
+
+            // apply preset region
+            for (EAS_U32 k = 0; k < presetRegion.genCount; k++) {
+                EAS_U16 genType;
+                EAS_I16 genValue;
+                result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->pgenOffset + presetRegion.genOffset + (k * GEN_SIZE));
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genType, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &genValue, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                if (genType == sfg_keyRange || genType == sfg_velRange || genType == sfg_instrument) {
+                    continue;
+                }
+                result = Check_gen(genType, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                if (IsValueGenerator(genType)) {
+                    gens[genType] += genValue;
+                } else {
+                    gens[genType] = genValue;
+                }
+            }
+
+            for (EAS_U32 k = 0; k < presetRegion.modCount; k++) {
+                if (modCount >= MAX_MODS_IN_MERGED_REGION) {
+                    EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: too many modulators in merged preset %u region %u\n", i - 1, instRegionIndex);
+                    return EAS_ERROR_SOUND_LIBRARY;
+                }
+                EAS_U16 modSrc;
+                EAS_U16 modDest;
+                EAS_U16 modAmount;
+                EAS_U16 modAmountSrc;
+                EAS_U16 modTransform;
+                result = EAS_HWFileSeek(pParser->hwInstData, pParser->fileHandle, pParser->pmodOffset + presetRegion.modOffset + (k * MOD_SIZE));
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modSrc, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modDest, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmount, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modAmountSrc, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+                result = EAS_HWGetWord(pParser->hwInstData, pParser->fileHandle, &modTransform, EAS_FALSE);
+                if (result != EAS_SUCCESS) {
+                    return result;
+                }
+
+                mods[modCount].src = modSrc;
+                mods[modCount].dest = modDest;
+                mods[modCount].amount = modAmount;
+                mods[modCount].amountSrc = modAmountSrc;
+                mods[modCount].transform = modTransform;
+                modCount++;
+            }
+
+            // apply range
+            gens[sfg_keyRange] = keyL | (keyH << 8); // LE
+            gens[sfg_velRange] = velL | (velH << 8); // LE
+
+            // parse
+            EAS_U32 regionIndex = pParser->presetRegionWritten;
+            EAS_U32 artIndex = pParser->presetArticulationWritten;
+
+            if (!createArticulation) {
+                artIndex = pInst->pSharedArticulationIndices[instRegionIndex];
+            }
+
+            if (artIndex >= pParser->presetArticulationCount) {
+                EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: written articulation count exceeds calculated count %u\n", (unsigned)pParser->presetArticulationCount);
+                return EAS_ERROR_DATA_INCONSISTENCY;
+            }
+
+            if (pParser->presetRegionWritten >= pParser->presetRegionCount) {
+                EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: written region count exceeds calculated count %u\n", (unsigned)pParser->presetRegionCount);
+                return EAS_ERROR_DATA_INCONSISTENCY;
+            }
+
+            EAS_I16 rootKey = gens[sfg_overridingRootKey];
+            EAS_U8 loopMode;
+            result = Parse_bag(pParser, gens, mods, modCount, &pParser->pPresetArticulations[artIndex], &pParser->pPresetRegions[regionIndex], &loopMode);
+            if (result != EAS_SUCCESS) {
+                EAS_Report(_EAS_SEVERITY_ERROR, "SF2Parser: Failed to parse merged region at pbag entry at 0x%lx\n", myOffset - PBAG_SIZE);
+                return result;
+            }
+
+            pParser->pPresetRegions[regionIndex].wtRegion.artIndex = artIndex;
+            pParser->pPresetRegions[regionIndex].wtRegion.waveIndex = sampleID;
+            if (rootKey == -1) {
+                rootKey = pParser->pShdrs[sampleID].rootKey;
+            }
+            if (loopMode != 0) {
+                pParser->pPresetRegions[regionIndex].wtRegion.loopStart += pParser->pShdrs[sampleID].loopStart - pParser->pShdrs[sampleID].start;
+                pParser->pPresetRegions[regionIndex].wtRegion.loopEnd += pParser->pShdrs[sampleID].loopEnd - pParser->pShdrs[sampleID].start;
+            } else {
+                pParser->pPresetRegions[regionIndex].wtRegion.loopStart = 0;
+                pParser->pPresetRegions[regionIndex].wtRegion.loopEnd = 0;
+            }
+            if (pParser->pPresetRegions[regionIndex].wtRegion.loopStart != pParser->pPresetRegions[regionIndex].wtRegion.loopEnd) {
+                pParser->pPresetRegions[regionIndex].wtRegion.region.keyGroupAndFlags |= REGION_FLAG_IS_LOOPED;
+            }
+            pParser->pPresetRegions[regionIndex].wtRegion.tuning = pParser->pShdrs[sampleID].staticTuning;
+            pParser->pPresetRegions[regionIndex].wtRegion.tuning -= rootKey * pParser->pPresetArticulations[artIndex].keyNumToPitch / 128; // convert to cents, 1 semitone = 100 cents
+
+            if (shareArticulation) {
+                pInst->pSharedArticulationIndices[instRegionIndex] = artIndex;
+            }
+
+            if (createArticulation) {
+                pParser->presetArticulationWritten++;
+            }
+            pParser->presetRegionWritten++;
+        } // for each region of presetregion's inst
+
+    skip:
+        prevGenIndex = genIndex;
+        prevModIndex = modIndex;
+    } // for each region of preset
+
+    return EAS_SUCCESS;
+}
+
+struct s_mod_src {
+    EAS_U8 index;
+    EAS_BOOL cc;
+    EAS_BOOL direction;
+    EAS_BOOL polarity;
+    EAS_U8 type;
+};
+
+inline static struct s_mod_src ModSrc(EAS_U16 src) {
+    struct s_mod_src tag;
+    tag.index = src & 0x3F;
+    tag.cc = (src & 0x80) != 0;
+    tag.direction = (src & 0x100) != 0;
+    tag.polarity = (src & 0x200) != 0;
+    tag.type = (src >> 10) & 0x7F;
+    return tag;
+}
+
+static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOper], void* pMods, EAS_U32 modCount, S_DLS_ARTICULATION* pDLSArt, S_DLS_REGION* pDLSRegion, EAS_U8* loopMode)
+{
+    *loopMode = 0; // no loop
+
+    if (gens[sfg_startAddrsOffset] != 0 || gens[sfg_endAddrsOffset] != 0 || gens[sfg_startAddrsCoarseOffset] != 0 || gens[sfg_endAddrsCoarseOffset] != 0) {
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: sample addrs offset is not supported\n");
+    }
+
+    pDLSArt->modLFO.lfoDelay = -DLSConvertDelay(gens[sfg_delayModLFO]);
+    pDLSArt->modLFO.lfoFreq = DLSConvertPitchToPhaseInc(gens[sfg_freqModLFO]);
+
+    pDLSArt->vibLFO.lfoDelay = -DLSConvertDelay(gens[sfg_delayVibLFO]);
+    pDLSArt->vibLFO.lfoFreq = DLSConvertPitchToPhaseInc(gens[sfg_freqVibLFO]);
+
+    pDLSArt->eg1.delayTime = DLSConvertDelay(gens[sfg_delayVolEnv]);
+    pDLSArt->eg1.attackTime = gens[sfg_attackVolEnv];
+    pDLSArt->eg1.holdTime = gens[sfg_holdVolEnv];
+    pDLSArt->eg1.decayTime = gens[sfg_decayVolEnv];
+    pDLSArt->eg1.sustainLevel = DLSConvertSustain(1000 - gens[sfg_sustainVolEnv]); // EG1 itself is in decibels
+    pDLSArt->eg1.releaseTime = DLSConvertDelay(gens[sfg_releaseVolEnv]);
+    pDLSArt->eg1.velToAttack = 0;
+    pDLSArt->eg1.keyNumToHold = -gens[sfg_keynumToVolEnvHold] * 128;
+    pDLSArt->eg1.keyNumToDecay = -gens[sfg_keynumToVolEnvDecay] * 128;
+    pDLSArt->eg1ShutdownTime = 0;
+
+    pDLSArt->eg2.delayTime = DLSConvertDelay(gens[sfg_delayModEnv]);
+    pDLSArt->eg2.attackTime = gens[sfg_attackModEnv];
+    pDLSArt->eg2.holdTime = gens[sfg_holdModEnv];
+    pDLSArt->eg2.decayTime = gens[sfg_decayModEnv];
+    pDLSArt->eg2.sustainLevel = DLSConvertSustain(1000 - gens[sfg_sustainModEnv]);
+    pDLSArt->eg2.releaseTime = DLSConvertDelay(gens[sfg_releaseModEnv]);
+    pDLSArt->eg2.velToAttack = 0;
+    pDLSArt->eg2.keyNumToHold = -gens[sfg_keynumToModEnvHold] * 128;
+    pDLSArt->eg2.keyNumToDecay = -gens[sfg_keynumToModEnvDecay] * 128;
+
+    // Key 60 have unmodified decay and hold time
+    pDLSArt->eg1.decayTime -= pDLSArt->eg1.keyNumToDecay / 128 * 60;
+    pDLSArt->eg1.holdTime -= pDLSArt->eg1.keyNumToHold / 128 * 60;
+    pDLSArt->eg2.decayTime -= pDLSArt->eg2.keyNumToDecay / 128 * 60;
+    pDLSArt->eg2.holdTime -= pDLSArt->eg2.keyNumToHold / 128 * 60;
+
+    pDLSArt->filterCutoff = gens[sfg_initialFilterFc];
+    pDLSArt->filterQandFlags = DLSConvertQ(gens[sfg_initialFilterQ]);
+    pDLSArt->modLFOToFc = gens[sfg_modLfoToFilterFc];
+    pDLSArt->modLFOCC1ToFc = 0;
+    pDLSArt->modLFOChanPressToFc = 0;
+    pDLSArt->eg2ToFc = gens[sfg_modEnvToFilterFc];
+    pDLSArt->velToFc = 0;
+    pDLSArt->keyNumToFc = 0;
+
+    pDLSArt->modLFOToGain = gens[sfg_modLfoToVolume];
+    pDLSArt->modLFOCC1ToGain = 0;
+    pDLSArt->modLFOChanPressToGain = 0;
+
+    pDLSArt->tuning = gens[sfg_coarseTune] * 100 + gens[sfg_fineTune]; // 100 cents = 1 semitone
+    pDLSArt->keyNumToPitch = 12800 * gens[sfg_scaleTuning] / 100;
+    pDLSArt->vibLFOToPitch = gens[sfg_vibLfoToPitch];
+    pDLSArt->vibLFOCC1ToPitch = 0;
+    pDLSArt->vibLFOChanPressToPitch = 0;
+    pDLSArt->modLFOToPitch = gens[sfg_modLfoToPitch];
+    pDLSArt->eg2ToPitch = gens[sfg_modEnvToPitch];
+
+    pDLSArt->pan = DLSConvertPan(gens[sfg_pan]);
+    
+#ifdef _CC_CHORUS
+    pDLSArt->chorusSend = gens[sfg_chorusEffectsSend];
+    pDLSArt->cc91ToReverbSend = 0;
+#endif
+#ifdef _CC_REVERB
+    pDLSArt->reverbSend = gens[sfg_reverbEffectsSend];
+    pDLSArt->cc93ToChorusSend = 0;
+#endif
+
+    // here we don't know loop region of the sample, so just put offsets here
+    pDLSRegion->wtRegion.loopStart = gens[sfg_startloopAddrsOffset] + 32768 * gens[sfg_startloopAddrsCoarseOffset];
+    pDLSRegion->wtRegion.loopEnd = gens[sfg_endloopAddrsOffset] + 32768 * gens[sfg_endloopAddrsCoarseOffset];
+    
+    // genValue is read as LE
+    pDLSRegion->wtRegion.region.rangeLow = (EAS_U8)(gens[sfg_keyRange] & 0x7F);
+    pDLSRegion->wtRegion.region.rangeHigh = (EAS_U8)((gens[sfg_keyRange] >> 8) & 0x7F);
+    if (pDLSRegion->wtRegion.region.rangeLow > pDLSRegion->wtRegion.region.rangeHigh) {
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Invalid key range (%d, %d) at generator entry\n", pDLSRegion->wtRegion.region.rangeLow, pDLSRegion->wtRegion.region.rangeHigh);
+    }
+    pDLSRegion->velLow = (EAS_U8)(gens[sfg_velRange] & 0x7F);
+    pDLSRegion->velHigh = (EAS_U8)((gens[sfg_velRange] >> 8) & 0x7F);
+    if (pDLSRegion->velLow > pDLSRegion->velHigh) {
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Invalid velocity range (%d, %d) at generator entry\n", pDLSRegion->velLow, pDLSRegion->velHigh);
+    }
+
+    // Each 1 dB of attenuation set at the instrument or preset level should only attenuate the sound by 0.4 dB.
+    // This is a quirk of the Sound Blaster hardware that should be emulated for compatibility with existing SoundFonts.
+    pDLSRegion->wtRegion.gain = -gens[sfg_initialAttenuation] * 4 / 10;
+
+    if (gens[sfg_sampleModes] == 1) { // loop forever
+        *loopMode = 1; // loop forever
+    } else if (gens[sfg_sampleModes] == 3) { // loop and release
+        // TODO: eas does not support this
+        *loopMode = 1; // loop forever
+    } else { // no loop
+        *loopMode = 0;
+    }
+
+    if (gens[sfg_exclusiveClass] > 0xFF) {
+        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: exclusive class number %u is too large at generator entry\n", gens[sfg_exclusiveClass]);
+        pDLSRegion->wtRegion.region.keyGroupAndFlags = REGION_FLAG_NON_SELF_EXCLUSIVE;
+    } else {
+        pDLSRegion->wtRegion.region.keyGroupAndFlags = ((EAS_U8)gens[sfg_exclusiveClass] << 8) | REGION_FLAG_NON_SELF_EXCLUSIVE;
+    }
+
+    // modulators
+    for (EAS_U32 i = 0; i < modCount; i++) {
+        const void* myOffset = pMods + (MOD_SIZE * (EAS_IPTR)i);
+        const EAS_U16 modSrc = *(EAS_U16*)myOffset;
+        const EAS_U16 modDest = *(EAS_I16*)(myOffset + 2);
+        const EAS_I16 modAmount = *(EAS_U16*)(myOffset + 4);
+        const EAS_U16 modControl = *(EAS_U16*)(myOffset + 6);
+        const EAS_U16 modTrans = *(EAS_U16*)(myOffset + 8);
+
+        //    Type      P  D   CC    Index
+        // 15 ----- 10 09 08 | 07 06 ----- 00
+        struct s_mod_src modSrcTag = ModSrc(modSrc);
+        
+        if (modSrcTag.index == sfm_noController) {
+            continue;
+        }
+
+        if (modSrc == 0x00DB // (type=0, P=0, D=0, CC=1, index = 91)
+            && modDest == sfg_reverbEffectsSend // CC91 -> reverbSend
+        ) {
+            if (modControl != 0) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: CC91 -> reverbSend does not support amount source 0x%04x\n", modControl);
+            }
+            if (modTrans != sft_Linear) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: CC91 -> reverbSend does not support transform 0x%04x\n", modTrans);
+            }
+            pDLSArt->cc91ToReverbSend += modAmount;
+        } else if (modSrc == 0x00DD // (type=0, P=0, D=0, CC=1, index = 93)
+            && modDest == sfg_chorusEffectsSend // CC93 -> chorusSend
+        ) {
+            if (modControl != 0) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: CC93 -> chorusSend does not support amount source 0x%04x\n", modControl);
+            }
+            if (modTrans != sft_Linear) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: CC93 -> chorusSend does not support transform 0x%04x\n", modTrans);
+            }
+            pDLSArt->cc93ToChorusSend += modAmount;
+        } else if ((modSrc & 0xFF) == 0x02) { // (CC=0, index = 2) noteon velocity
+            if (modSrcTag.polarity == EAS_TRUE) {
+                goto invalid;
+            }
+            if (modControl != 0) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: note-on velocity does not support amount source 0x%04x\n", modControl);
+            }
+            if (modTrans != sft_Linear) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: note-on velocity does not support transform 0x%04x\n", modTrans);
+            }
+            switch (modDest) {
+            case sfg_attackVolEnv:
+                if (modSrcTag.type != sfct_Linear) {
+                    EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: velToVolAttack does not support non-linear controller type 0x%02x\n", modTrans);
+                }
+                if (modSrcTag.direction == EAS_FALSE) { // 0 ~ 127
+                    pDLSArt->eg1.velToAttack += modAmount;
+                } else { // 127 ~ 0
+                    pDLSArt->eg1.velToAttack -= modAmount;
+                    pDLSArt->eg1.attackTime += modAmount;
+                }
+                break;
+            case sfg_attackModEnv:
+                if (modSrcTag.type != sfct_Linear) {
+                    EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: velToModAttack does not support non-linear controller type 0x%02x\n", modTrans);
+                }
+                if (modSrcTag.direction == EAS_FALSE) { // 0 ~ 127
+                    pDLSArt->eg2.velToAttack += modAmount;
+                } else { // 127 ~ 0
+                    pDLSArt->eg2.velToAttack -= modAmount;
+                    pDLSArt->eg2.attackTime += modAmount;
+                }
+                break;
+            case sfg_initialFilterFc:
+                if (modSrcTag.type != sfct_Linear) {
+                    EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: velToFc does not support non-linear controller type 0x%02x\n", modTrans);
+                }
+                if (modSrcTag.direction == EAS_FALSE) { // 0 ~ 127
+                    pDLSArt->velToFc = modAmount;
+                } else { // 127 ~ 0
+                    pDLSArt->velToFc -= modAmount;
+                    pDLSArt->filterCutoff += modAmount;
+                }
+                break;
+            case sfg_initialAttenuation:
+                if (modSrcTag.type != sfct_Concave) {
+                    EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: velToAttenuation does not support non-concave controller type 0x%02x\n", modTrans);
+                }
+                if (abs(modAmount) < 5) { // 0.5 dB
+                    pDLSArt->filterQandFlags &= ~FLAG_DLS_VELOCITY_SENSITIVE;
+                } else {
+                    if (modAmount != 960) { // 96 dB
+                        EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: velToAttenuation does not support modAmount which is neither default nor non-zero: %d\n", (int)modAmount);
+                    }
+                    pDLSArt->filterQandFlags |= FLAG_DLS_VELOCITY_SENSITIVE;
+                }
+                break;
+            default:
+                goto invalid;
+            }
+        } else if (modSrc == 0x0003) { // (type=0, P=0, D=0, CC=0, index = 3) noteon key number
+            if (modControl != 0) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: note-on key number does not support amount source 0x%04x\n", modControl);
+            }
+            if (modTrans != sft_Linear) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: note-on key number does not support transform 0x%04x\n", modTrans);
+            }
+            switch (modDest) {
+            case sfg_initialFilterFc:
+                pDLSArt->keyNumToFc += modAmount;
+                break;
+            default:
+                goto invalid;
+            }
+        } else if (modSrc == 0x000D) { // (type=0, P=0, D=0, CC=0, index = 13) midi channel pressure
+            if (modControl != 0) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: midi channel pressure does not support amount source 0x%04x\n", modControl);
+            }
+            if (modTrans != sft_Linear) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: midi channel pressure does not support transform 0x%04x\n", modTrans);
+            }
+            switch (modDest) {
+            case sfg_vibLfoToPitch:
+                pDLSArt->modLFOChanPressToPitch += modAmount;
+                break;
+            case sfg_modLfoToFilterFc:
+                pDLSArt->modLFOChanPressToFc += modAmount;
+                break;
+            case sfg_modLfoToVolume:
+                pDLSArt->modLFOChanPressToGain += modAmount;
+                break;
+            default:
+                goto invalid;
+            }
+        } else if (modSrc == 0x0081) { // (type=0, P=0, D=0, CC=1, index = 1) CC1
+            if (modControl != 0) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: CC1 does not support amount source 0x%04x\n", modControl);
+            }
+            if (modTrans != sft_Linear) {
+                EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: CC1 does not support transform 0x%04x\n", modTrans);
+            }
+            switch (modDest) {
+            case sfg_modLfoToFilterFc:
+                pDLSArt->modLFOCC1ToFc += modAmount;
+                break;
+            case sfg_modLfoToVolume:
+                pDLSArt->modLFOCC1ToGain += modAmount;
+                break;
+            case sfg_vibLfoToPitch:
+                pDLSArt->vibLFOCC1ToPitch += modAmount;
+                break;
+            case sfg_modLfoToPitch:
+                pDLSArt->modLFOCC1ToPitch += modAmount;
+                break;
+            default:
+                goto invalid;
+            }
+        } else {
+        invalid:
+            EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: Unsupported modulator 0x%04x*(0x%04x)--(%u)->0x%04x\n", modSrc, modControl, (unsigned)modTrans, modDest);
+        }
+    }
+
+    if (gens[sfg_keynum] != -1) {
+        pDLSArt->keyNumToPitch = 0;
+        pDLSArt->tuning += gens[sfg_keynum] * 100;
+    }
+
+    if (gens[sfg_velocity] != -1 && (pDLSArt->filterQandFlags & FLAG_DLS_VELOCITY_SENSITIVE)) {
+        pDLSRegion->wtRegion.gain += -960 * (127 - gens[sfg_velocity]) / 128;
+        pDLSArt->filterQandFlags &= ~FLAG_DLS_VELOCITY_SENSITIVE;
+    }
+
+    // TODO: EAS's filter implementation is weird, SF2's defaul value (13500 20kHz) still cause a significant amount of treble reduction
+    // TODO: This line will disable the filter. A new filter implementation may be needed
+    pDLSArt->filterCutoff = DEFAULT_DLS_FILTER_CUTOFF_FREQUENCY;
+
+    return EAS_SUCCESS;
+}

--- a/arm-wt-22k/lib_src/eas_sf2.h
+++ b/arm-wt-22k/lib_src/eas_sf2.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "eas_data.h"
+#include "eas_types.h"
+#include "eas_sndlib.h"
 
 // Usually it is not needed to directly call this function, DLSParser will invoke it
 EAS_RESULT SF2Parser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle, EAS_I32 offset, S_DLS **pDLS);

--- a/arm-wt-22k/lib_src/eas_sf2.h
+++ b/arm-wt-22k/lib_src/eas_sf2.h
@@ -3,6 +3,8 @@
 #include "eas_types.h"
 #include "eas_sndlib.h"
 
+#ifdef _SF2_SUPPORT
 // Usually it is not needed to directly call this function, DLSParser will invoke it
 EAS_RESULT SF2Parser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle, EAS_I32 offset, S_DLS **pDLS);
 EAS_RESULT SF2Cleanup (EAS_HW_DATA_HANDLE hwInstData, S_DLS *pDLS);
+#endif

--- a/arm-wt-22k/lib_src/eas_sf2.h
+++ b/arm-wt-22k/lib_src/eas_sf2.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "eas_data.h"
+
+// Usually it is not needed to directly call this function, DLSParser will invoke it
+EAS_RESULT SF2Parser (EAS_HW_DATA_HANDLE hwInstData, EAS_FILE_HANDLE fileHandle, EAS_I32 offset, S_DLS **pDLS);
+EAS_RESULT SF2Cleanup (EAS_HW_DATA_HANDLE hwInstData, S_DLS *pDLS);

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -325,6 +325,10 @@ typedef struct s_bank_tag
 #define LIB_FORMAT_16_BIT_SAMPLES       0x00200000
 
 #ifdef DLS_SYNTHESIZER
+enum : int {
+    DLSLIB_TYPE_DLS = 0x00,
+    DLSLIB_TYPE_SF2 = 0x10
+};
 /*----------------------------------------------------------------------------
  * DLS data structure
  *
@@ -352,6 +356,7 @@ typedef struct s_eas_dls_tag
     EAS_U16             numDLSArticulations;
     EAS_U16             numDLSSamples;
     EAS_U8              refCount;
+    EAS_U8              libType;
 } S_DLS;
 #endif
 

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -325,7 +325,7 @@ typedef struct s_bank_tag
 #define LIB_FORMAT_16_BIT_SAMPLES       0x00200000
 
 #ifdef DLS_SYNTHESIZER
-enum : int {
+enum E_DLSLIB_TYPE : int {
     DLSLIB_TYPE_DLS = 0x00,
     DLSLIB_TYPE_SF2 = 0x10
 };

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -194,7 +194,7 @@ typedef struct s_dls_articulation_tag
     EAS_U16         pad;
 
     EAS_I8          pan;
-    EAS_U8          filterQandFlags;
+    EAS_U16         filterQandFlags;
 
 #ifdef _CC_REVERB
     EAS_I16         reverbSend;
@@ -210,8 +210,8 @@ typedef struct s_dls_articulation_tag
 /* flags in filterQandFlags
  * NOTE: Q is stored in bottom 5 bits
  */
-#define FLAG_DLS_VELOCITY_SENSITIVE     0x80
-#define FILTER_Q_MASK                   0x1f
+#define FLAG_DLS_VELOCITY_SENSITIVE     0x8000
+#define FILTER_Q_MASK                   0x7fff
 
 /*----------------------------------------------------------------------------
  * Wavetable region data structure

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -325,7 +325,7 @@ typedef struct s_bank_tag
 #define LIB_FORMAT_16_BIT_SAMPLES       0x00200000
 
 #ifdef DLS_SYNTHESIZER
-enum E_DLSLIB_TYPE : int {
+enum {
     DLSLIB_TYPE_DLS = 0x00,
     DLSLIB_TYPE_SF2 = 0x10
 };

--- a/arm-wt-22k/lib_src/eas_voicemgt.c
+++ b/arm-wt-22k/lib_src/eas_voicemgt.c
@@ -1591,7 +1591,7 @@ void VMCheckKeyGroup (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, EAS_U16 keyGroup,
             {
                 /* check key group */
                 pRegion = GetRegionPtr(pSynth, pVoiceMgr->voices[voiceNum].regionIndex);
-                if (keyGroup == (pRegion->keyGroupAndFlags & 0x0f00))
+                if (keyGroup == (pRegion->keyGroupAndFlags >> 8))
                 {
 #ifdef _DEBUG_VM
                     { /* dpp: EAS_ReportEx(_EAS_SEVERITY_INFO, "VMCheckKeyGroup: voice %d matches key group %d\n", voiceNum, keyGroup >> 8); */ }
@@ -1616,7 +1616,7 @@ void VMCheckKeyGroup (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, EAS_U16 keyGroup,
             {
                 /* check key group */
                 pRegion = GetRegionPtr(pSynth, pVoiceMgr->voices[voiceNum].nextRegionIndex);
-                if (keyGroup == (pRegion->keyGroupAndFlags & 0x0f00))
+                if (keyGroup == (pRegion->keyGroupAndFlags >> 8))
                 {
 #ifdef _DEBUG_VM
                     { /* dpp: EAS_ReportEx(_EAS_SEVERITY_INFO, "VMCheckKeyGroup: voice %d matches key group %d\n", voiceNum, keyGroup >> 8); */ }
@@ -1778,7 +1778,7 @@ void VMStartVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, EAS_U8 channel, EAS_
     {
 
         /* check for key group exclusivity */
-        keyGroup = pRegion->keyGroupAndFlags & 0x0f00;
+        keyGroup = pRegion->keyGroupAndFlags >> 8;
         if (keyGroup!= 0)
             VMCheckKeyGroup(pVoiceMgr, pSynth, keyGroup, channel);
 

--- a/arm-wt-22k/lib_src/eas_wt_IPC_frame.h
+++ b/arm-wt-22k/lib_src/eas_wt_IPC_frame.h
@@ -36,6 +36,8 @@
  *----------------------------------------------------------------------------
 */
 
+#include "eas_types.h"
+
 #ifndef _EAS_WT_IPC_FRAME_H
 #define _EAS_WT_IPC_FRAME_H
 
@@ -52,9 +54,11 @@ typedef struct s_wt_frame_tag
     EAS_I32         phaseIncrement; // phase increment per sample
 
 #if defined(_FILTER_ENABLED)
-    EAS_I32         k;
-    EAS_I32         b1;
-    EAS_I32         b2;
+    // General 2-pole IIR transfer function is: H(z) = (b0 + b1 * z^-1 + b2 * z^-2) / (1 + a1 * z^-1 + a2 * z^-2)
+    float a1;
+    float a2;
+    float b02;
+    float b1;
 #endif
 } S_WT_FRAME;
 

--- a/arm-wt-22k/lib_src/eas_wt_IPC_frame.h
+++ b/arm-wt-22k/lib_src/eas_wt_IPC_frame.h
@@ -54,11 +54,17 @@ typedef struct s_wt_frame_tag
     EAS_I32         phaseIncrement; // phase increment per sample
 
 #if defined(_FILTER_ENABLED)
+#ifdef _FLOAT_DCF
     // General 2-pole IIR transfer function is: H(z) = (b0 + b1 * z^-1 + b2 * z^-2) / (1 + a1 * z^-1 + a2 * z^-2)
     float a1;
     float a2;
     float b02;
     float b1;
+#else
+    EAS_I32         k;
+    EAS_I32         b1;
+    EAS_I32         b2;
+#endif
 #endif
 } S_WT_FRAME;
 

--- a/arm-wt-22k/lib_src/eas_wtengine.c
+++ b/arm-wt-22k/lib_src/eas_wtengine.c
@@ -57,6 +57,10 @@ extern void WT_InterpolateNoLoop (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFr
 extern void WT_Interpolate (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pWTIntFrame);
 #endif
 
+#if defined(_FILTER_ENABLED)
+extern void WT_VoiceFilter (S_FILTER_CONTROL*pFilter, S_WT_INT_FRAME *pWTIntFrame);
+#endif
+
 // The PRNG in WT_NoiseGenerator relies on modulo math
 #undef  NO_INT_OVERFLOW_CHECKS
 #if defined(_MSC_VER)

--- a/arm-wt-22k/lib_src/eas_wtengine.h
+++ b/arm-wt-22k/lib_src/eas_wtengine.h
@@ -41,6 +41,7 @@
 
 #include "eas_sndlib.h"
 #include "eas_wt_IPC_frame.h"
+#include "eas_filter.h"
 
 /*----------------------------------------------------------------------------
  * defines
@@ -69,19 +70,6 @@ typedef struct s_wt_int_frame_tag
     EAS_I32         prevGain;
 } S_WT_INT_FRAME;
 
-#if defined(_FILTER_ENABLED)
-/*----------------------------------------------------------------------------
- * S_FILTER_CONTROL data structure
- *----------------------------------------------------------------------------
-*/
-typedef struct s_filter_control_tag
-{
-    EAS_I32     y1;                             /* 1 sample delay state variable */
-    EAS_I32     y2;                             /* 2 sample delay state variable */
-    EAS_I32     x1;                             /* 1 sample delay input variable */
-    EAS_I32     x2;                             /* 2 sample delay input variable */
-} S_FILTER_CONTROL;
-#endif
 
 /*------------------------------------
  * S_LFO_CONTROL data structure

--- a/arm-wt-22k/lib_src/eas_wtengine.h
+++ b/arm-wt-22k/lib_src/eas_wtengine.h
@@ -76,8 +76,10 @@ typedef struct s_wt_int_frame_tag
 */
 typedef struct s_filter_control_tag
 {
-    EAS_I32     z1;                             /* 1 sample delay state variable */
-    EAS_I32     z2;                             /* 2 sample delay state variable */
+    EAS_I32     y1;                             /* 1 sample delay state variable */
+    EAS_I32     y2;                             /* 2 sample delay state variable */
+    EAS_I32     x1;                             /* 1 sample delay input variable */
+    EAS_I32     x2;                             /* 2 sample delay input variable */
 } S_FILTER_CONTROL;
 #endif
 

--- a/arm-wt-22k/lib_src/eas_wtengine.h
+++ b/arm-wt-22k/lib_src/eas_wtengine.h
@@ -76,8 +76,8 @@ typedef struct s_wt_int_frame_tag
 */
 typedef struct s_filter_control_tag
 {
-    EAS_I16     z1;                             /* 1 sample delay state variable */
-    EAS_I16     z2;                             /* 2 sample delay state variable */
+    EAS_I32     z1;                             /* 1 sample delay state variable */
+    EAS_I32     z2;                             /* 2 sample delay state variable */
 } S_FILTER_CONTROL;
 #endif
 

--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -142,8 +142,10 @@ static EAS_RESULT WT_Initialize (S_VOICE_MGR *pVoiceMgr)
         pVoiceMgr->wtVoices[i].phaseAccum = DEFAULT_PHASE_INT;
 
 #ifdef _FILTER_ENABLED
-        pVoiceMgr->wtVoices[i].filter.z1 = DEFAULT_FILTER_ZERO;
-        pVoiceMgr->wtVoices[i].filter.z2 = DEFAULT_FILTER_ZERO;
+        pVoiceMgr->wtVoices[i].filter.y1 = 0;
+        pVoiceMgr->wtVoices[i].filter.y2 = 0;
+        pVoiceMgr->wtVoices[i].filter.x1 = 0;
+        pVoiceMgr->wtVoices[i].filter.x2 = 0;
 #endif
     }
 
@@ -379,8 +381,10 @@ static EAS_RESULT WT_StartVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNT
 
 #ifdef _FILTER_ENABLED
     /* clear out the filter states */
-    pWTVoice->filter.z1 = 0;
-    pWTVoice->filter.z2 = 0;
+    pWTVoice->filter.y1 = 0;
+    pWTVoice->filter.y2 = 0;
+    pWTVoice->filter.x1 = 0;
+    pWTVoice->filter.x2 = 0;
 #endif
 
     /* if this wave is to be generated using noise generator */
@@ -560,7 +564,7 @@ static EAS_BOOL WT_UpdateVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNTH
     if (pSynth->pEAS->libAttr & LIB_FORMAT_FILTER_ENABLED)
         WT_UpdateFilter(pWTVoice, &intFrame, pArt);
     else
-        intFrame.frame.k = 0;
+        intFrame.frame.b02 = 0;
 #endif
 
     /* update the gain */
@@ -1049,7 +1053,7 @@ static void WT_UpdateFilter (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pIntFrame, co
     /* no need to calculate filter coefficients if it is bypassed */
     if (pArt->filterCutoff == DEFAULT_EAS_FILTER_CUTOFF_FREQUENCY)
     {
-        pIntFrame->frame.k = 0;
+        pIntFrame->frame.b02 = 0;
         return;
     }
 
@@ -1062,253 +1066,17 @@ static void WT_UpdateFilter (S_WT_VOICE *pWTVoice, S_WT_INT_FRAME *pIntFrame, co
 #endif
 
 #if defined(_FILTER_ENABLED) || defined(DLS_SYNTHESIZER)
-#if 0 // This is original code from EAS. Its cutoff is limited and I can't find another good limit for it
-/*----------------------------------------------------------------------------
- * coef
- *----------------------------------------------------------------------------
- * Table of filter coefficients for low-pass filter
- *----------------------------------------------------------------------------
- *
- * polynomial coefficients are based on 8kHz sampling frequency
- * filter coef b2 = k2 = k2g0*k^0 + k2g1*k^1*(2^x) + k2g2*k^2*(2^x)
- *
- *where k2g0, k2g1, k2g2 are from the truncated power series expansion on theta
- *(k*2^x = theta, but we incorporate the k along with the k2g0, k2g1, k2g2)
- *note: this is a power series in 2^x, not k*2^x
- *where k = (2*pi*440)/8kHz == convert octaves to radians
- *
- *  so actually, the following coefs listed as k2g0, k2g1, k2g2 are really
- *  k2g0*k^0 = k2g0
- *  k2g1*k^1
- *  k2g2*k^2
- *
- *
- * filter coef n1 = numerator = n1g0*k^0 + n1g1*k^1*(2^x) + n1g2*k^2*(2^x) + n1g3*k^3*(2^x)
- *
- *where n1g0, n1g1, n1g2, n1g3 are from the truncated power series expansion on theta
- *(k*2^x = theta, but we incorporate the k along with the n1g0, n1g1, n1g2, n2g3)
- *note: this is a power series in 2^x, not k*2^x
- *where k = (2*pi*440)/8kHz == convert octaves to radians
- *we also include the optimization factor of 0.81
- *
- *  so actually, the following coefs listed as n1g0, n1g1, n1g2, n2g3 are really
- *  n1g0*k^0 = n1g0
- *  n1g1*k^1
- *  n1g2*k^2
- *  n1g3*k^3
- *
- *  NOTE that n1g0 == n1g1 == 0, always, so we only need to store n1g2 and n1g3
- *----------------------------------------------------------------------------
-*/
-
-static const EAS_I16 nk1g0 = -32768;
-static const EAS_I16 nk1g2 = 1580;
-static const EAS_I16 k2g0 = 32767;
-
-static const EAS_I16 k2g1[] =
-{
-        -11324, /* k2g1[0] = -0.3455751918948761 */
-        -10387, /* k2g1[1] = -0.3169878073928751 */
-        -9528,  /* k2g1[2] = -0.29076528753345476 */
-        -8740,  /* k2g1[3] = -0.2667120011011279 */
-        -8017,  /* k2g1[4] = -0.24464850028971705 */
-        -7353,  /* k2g1[5] = -0.22441018194495696 */
-        -6745,  /* k2g1[6] = -0.20584605955455101 */
-        -6187,  /* k2g1[7] = -0.18881763682420102 */
-        -5675,  /* k2g1[8] = -0.1731978744360067 */
-        -5206,  /* k2g1[9] = -0.15887024228080968 */
-        -4775,  /* k2g1[10] = -0.14572785009373057 */
-        -4380,  /* k2g1[11] = -0.13367265000706827 */
-        -4018,  /* k2g1[12] = -0.1226147050712642 */
-        -3685,  /* k2g1[13] = -0.11247151828678581 */
-        -3381,  /* k2g1[14] = -0.10316741714122014 */
-        -3101,  /* k2g1[15] = -0.0946329890599603 */
-        -2844,  /* k2g1[16] = -0.08680456355870586 */
-        -2609,  /* k2g1[17] = -0.07962373723441349 */
-        -2393,  /* k2g1[18] = -0.07303693805092666 */
-        -2195,  /* k2g1[19] = -0.06699502566866912 */
-        -2014,  /* k2g1[20] = -0.06145292483669077 */
-        -1847,  /* k2g1[21] = -0.056369289112013346 */
-        -1694,  /* k2g1[22] = -0.05170619239747895 */
-        -1554,  /* k2g1[23] = -0.04742884599684141 */
-        -1426,  /* k2g1[24] = -0.043505339076210514 */
-        -1308,  /* k2g1[25] = -0.03990640059558053 */
-        -1199,  /* k2g1[26] = -0.03660518093435039 */
-        -1100,  /* k2g1[27] = -0.03357705158166837 */
-        -1009,  /* k2g1[28] = -0.030799421397205727 */
-        -926,   /* k2g1[29] = -0.028251568071585884 */
-        -849    /* k2g1[30] = -0.025914483529091967 */
-};
-
-static const EAS_I16 k2g2[] =
-{
-        1957,   /* k2g2[0] = 0.059711106626580836 */
-        1646,   /* k2g2[1] = 0.05024063501786333 */
-        1385,   /* k2g2[2] = 0.042272226217199664 */
-        1165,   /* k2g2[3] = 0.03556764576567844 */
-        981,    /* k2g2[4] = 0.029926444346999134 */
-        825,    /* k2g2[5] = 0.025179964880280382 */
-        694,    /* k2g2[6] = 0.02118630011706455 */
-        584,    /* k2g2[7] = 0.01782604998793514 */
-        491,    /* k2g2[8] = 0.014998751854573014 */
-        414,    /* k2g2[9] = 0.012619876941179595 */
-        348,    /* k2g2[10] = 0.010618303146468736 */
-        293,    /* k2g2[11] = 0.008934188679954682 */
-        246,    /* k2g2[12] = 0.007517182949855368 */
-        207,    /* k2g2[13] = 0.006324921212866403 */
-        174,    /* k2g2[14] = 0.005321757979794424 */
-        147,    /* k2g2[15] = 0.004477701309210577 */
-        123,    /* k2g2[16] = 0.00376751612730811 */
-        104,    /* k2g2[17] = 0.0031699697655869644 */
-        87,     /* k2g2[18] = 0.00266719715992703 */
-        74,     /* k2g2[19] = 0.0022441667321724647 */
-        62,     /* k2g2[20] = 0.0018882309854916855 */
-        52,     /* k2g2[21] = 0.0015887483774966232 */
-        44,     /* k2g2[22] = 0.0013367651661223448 */
-        37,     /* k2g2[23] = 0.0011247477162958733 */
-        31,     /* k2g2[24] = 0.0009463572640678758 */
-        26,     /* k2g2[25] = 0.0007962604042473498 */
-        22,     /* k2g2[26] = 0.0006699696356181593 */
-        18,     /* k2g2[27] = 0.0005637091964589207 */
-        16,     /* k2g2[28] = 0.00047430217920125243 */
-        13,     /* k2g2[29] = 0.00039907554925166274 */
-        11      /* k2g2[30] = 0.00033578022828973666 */
-};
-
-static const EAS_I16 n1g2[] =
-{
-        3170,   /* n1g2[0] = 0.0967319927350769 */
-        3036,   /* n1g2[1] = 0.0926446051254155 */
-        2908,   /* n1g2[2] = 0.08872992911818503 */
-        2785,   /* n1g2[3] = 0.08498066682523227 */
-        2667,   /* n1g2[4] = 0.08138982872895201 */
-        2554,   /* n1g2[5] = 0.07795072065216213 */
-        2446,   /* n1g2[6] = 0.0746569312785634 */
-        2343,   /* n1g2[7] = 0.07150232020051943 */
-        2244,   /* n1g2[8] = 0.06848100647187474 */
-        2149,   /* n1g2[9] = 0.06558735764447099 */
-        2058,   /* n1g2[10] = 0.06281597926792246 */
-        1971,   /* n1g2[11] = 0.06016170483307614 */
-        1888,   /* n1g2[12] = 0.05761958614040857 */
-        1808,   /* n1g2[13] = 0.05518488407540374 */
-        1732,   /* n1g2[14] = 0.052853059773715245 */
-        1659,   /* n1g2[15] = 0.05061976615964251 */
-        1589,   /* n1g2[16] = 0.04848083984214659 */
-        1521,   /* n1g2[17] = 0.046432293353298 */
-        1457,   /* n1g2[18] = 0.04447030771468711 */
-        1396,   /* n1g2[19] = 0.04259122531793907 */
-        1337,   /* n1g2[20] = 0.040791543106060944 */
-        1280,   /* n1g2[21] = 0.03906790604290942 */
-        1226,   /* n1g2[22] = 0.037417100858604564 */
-        1174,   /* n1g2[23] = 0.035836050059229754 */
-        1125,   /* n1g2[24] = 0.03432180618965023 */
-        1077,   /* n1g2[25] = 0.03287154633875494 */
-        1032,   /* n1g2[26] = 0.03148256687687814 */
-        988,    /* n1g2[27] = 0.030152278415589925 */
-        946,    /* n1g2[28] = 0.028878200980459685 */
-        906,    /* n1g2[29] = 0.02765795938779331 */
-        868     /* n1g2[30] = 0.02648927881672521 */
-};
-
-static const EAS_I16 n1g3[] =
-{
-        -548,   /* n1g3[0] = -0.016714088475899017 */
-        -481,   /* n1g3[1] = -0.014683605122742116 */
-        -423,   /* n1g3[2] = -0.012899791676436092 */
-        -371,   /* n1g3[3] = -0.01133268185193299 */
-        -326,   /* n1g3[4] = -0.00995594976868754 */
-        -287,   /* n1g3[5] = -0.008746467702146129 */
-        -252,   /* n1g3[6] = -0.00768391756106361 */
-        -221,   /* n1g3[7] = -0.006750449563854721 */
-        -194,   /* n1g3[8] = -0.005930382380083576 */
-        -171,   /* n1g3[9] = -0.005209939699767622 */
-        -150,   /* n1g3[10] = -0.004577018805123356 */
-        -132,   /* n1g3[11] = -0.004020987256990177 */
-        -116,   /* n1g3[12] = -0.003532504280467257 */
-        -102,   /* n1g3[13] = -0.00310336384922047 */
-        -89,    /* n1g3[14] = -0.002726356832432369 */
-        -78,    /* n1g3[15] = -0.002395149888601605 */
-        -69,    /* n1g3[16] = -0.0021041790717285314 */
-        -61,    /* n1g3[17] = -0.0018485563625771063 */
-        -53,    /* n1g3[18] = -0.001623987554831628 */
-        -47,    /* n1g3[19] = -0.0014267001167177025 */
-        -41,    /* n1g3[20] = -0.0012533798162347005 */
-        -36,    /* n1g3[21] = -0.0011011150453668693 */
-        -32,    /* n1g3[22] = -0.0009673479079754438 */
-        -28,    /* n1g3[23] = -0.0008498312496971563 */
-        -24,    /* n1g3[24] = -0.0007465909079943587 */
-        -21,    /* n1g3[25] = -0.0006558925481952733 */
-        -19,    /* n1g3[26] = -0.0005762125284029567 */
-        -17,    /* n1g3[27] = -0.0005062123038325457 */
-        -15,    /* n1g3[28] = -0.0004447159405951901 */
-        -13,    /* n1g3[29] = -0.00039069036118270117 */
-        -11     /* n1g3[30] = -0.00034322798979677605 */
-};
-
-/*----------------------------------------------------------------------------
- * WT_SetFilterCoeffs()
- *----------------------------------------------------------------------------
- * Purpose:
- * Update the Filter parameters
- *
- * Inputs:
- * pVoice - ptr to the voice whose filter we want to update
- * pEASData - pointer to overall EAS data structure
- *
- * Outputs:
- *
- * Side Effects:
- * - updates Filter values for the given voice
- *----------------------------------------------------------------------------
-*/
-void WT_SetFilterCoeffs (S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance)
-{
-    EAS_I32 temp;
-
-    /* subtract the A5 offset and the sampling frequency */
-    cutoff -= FILTER_CUTOFF_FREQ_ADJUST + A5_PITCH_OFFSET_IN_CENTS;
-
-    /* limit the cutoff frequency */
-    if (cutoff > FILTER_CUTOFF_MAX_PITCH_CENTS)
-        cutoff = FILTER_CUTOFF_MAX_PITCH_CENTS;
-    else if (cutoff < FILTER_CUTOFF_MIN_PITCH_CENTS)
-        cutoff = FILTER_CUTOFF_MIN_PITCH_CENTS;
-
-    /*
-    Convert the cutoff, which has had A5 subtracted, using the 2^x approx
-    Note, this cutoff is related to theta cutoff by
-    theta = k * 2^x
-    We use 2^x and incorporate k in the power series coefs instead
-    */
-    cutoff = EAS_Calculate2toX(cutoff);
-
-    // temp seems to be .15 frac
-    // now frame is .14 frac
-
-    /* calculate b2 coef */
-    temp = k2g1[resonance] + MULT_AUDIO_COEF(cutoff, k2g2[resonance]);
-    temp = k2g0 + MULT_AUDIO_COEF(cutoff, temp);
-    pIntFrame->frame.b2 = temp >> 1;
-
-    /* calculate b1 coef */
-    temp = MULT_AUDIO_COEF(cutoff, nk1g2);
-    temp = nk1g0 + MULT_AUDIO_COEF(cutoff, temp);
-    temp += MULT_AUDIO_COEF(temp, pIntFrame->frame.b2);
-    pIntFrame->frame.b1 = temp >> 1;
-
-    /* calculate K coef */
-    temp = n1g2[resonance] + MULT_AUDIO_COEF(cutoff, n1g3[resonance]);
-    temp = MULT_AUDIO_COEF(cutoff, temp);
-    temp = MULT_AUDIO_COEF(cutoff, temp);
-    pIntFrame->frame.k = temp >> 1;
-}
-#else
 // A complete rewrite
 // I'm not sure how it works, anyway it works well
 /* 
  * Compute filter coefficients for a 2nd-order (2-pole) low-pass IIR filter
- * k, b1, b2's definition accords with DLS 2.2 specification.
-*/
+ *
+ * General 2-pole IIR transfer function is:
+ *  H(z) = (b0 + b1 * z^-1 + b2 * z^-2) / (1 + a1 * z^-1 + a2 * z^-2)
+ * Its difference equation is:
+ *  y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] - a1 * y[n-1] - a2 * y[n-2]
+ *
+ */
 void WT_SetFilterCoeffs(S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance) {
     double fc = pow(2.0, (cutoff - 6900.0) / 1200.0) * 440.0;
 
@@ -1318,45 +1086,38 @@ void WT_SetFilterCoeffs(S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 reson
     fc = fmax(fmin(fc, max_fc), min_fc);
 
     // EAS's resonance is in 0.75dB steps
-    const double resonance_dB = fmax(resonance * 0.75, 0.0);
+    const double resonance_dB = fmax(resonance / 10.0, 0.0);
 
     // filter pole angle
-    const double theta = 2.0 * M_PI * fc / fs;  // 数字域截止频率（弧度）
-    const double sin_theta = sin(theta);
-    const double cos_theta = cos(theta);
+    const double theta = 2.0 * M_PI * fc / fs;
 
-    // pole radius using resonance formula
-    const double sqrt_term = sqrt(pow(10.0, resonance_dB / 10.0) - 1.0);
-    const double r_denominator = pow(10.0, resonance_dB / 20.0) * sin_theta + 1.0;
-    const double r_numerator = cos_theta + sin_theta * sqrt_term;
-    double r = r_numerator / r_denominator;
-    r = fmin(r, 0.999);  // ensure stability (r < 1)
+    const double T = 1.0 / _OUTPUT_SAMPLE_RATE;
+    const double omega0 = 2.0 * _OUTPUT_SAMPLE_RATE * tan(theta / 2);
+    double q;
+    if (resonance_dB < 1e-9) {
+        q = 1 / sqrt(2); // default Q for Butterworth filter
+    } else {
+        q = pow(10.0, resonance_dB / 20.0);
+    }
 
-    // compute filter coefficients, matching DLS 2.2 transfer function
-    // H(z) = K/(1 + b1*z^-1 + b2*z^-2)
-    const double b1 = -2.0 * r * cos_theta;
-    const double b2 = r * r;
+    const double omega0T = omega0 * T;
+    const double D = 4 + 2 * omega0T / q + omega0T * omega0T;
+
+    // compute filter coefficients
+    const double a1 = (-8 + 2 * (omega0T * omega0T)) / D;
+    const double a2 = (4 - 2 * omega0T / q + omega0T * omega0T) / D;
+    double b02 = omega0T * omega0T / D;
+    double b1 = 2 * (omega0T * omega0T) / D;
+
+    // apply resonance gain compensation
     const double g = pow(10.0, -resonance_dB / 40.0);
-    const double K = g * (1.0 + b1 + b2);
+    b02 *= g;
+    b1 *= g;
 
-    const double scale = 1 << 15;
-    const EAS_I32 lim = 1 << 16;
-
-    EAS_I32 fixed_b1 = b1 * scale;
-    EAS_I32 fixed_b2 = b2 * scale;
-    EAS_I32 fixed_k = K * scale;
-
-    if (fixed_b1 > lim - 1) fixed_b1 = lim - 1;
-    if (fixed_b1 < -lim) fixed_b1 = -lim;
-    if (fixed_b2 > lim - 1) fixed_b2 = lim - 1;
-    if (fixed_b2 < -lim) fixed_b2 = -lim;
-    if (fixed_k > lim - 1) fixed_k = lim - 1;
-    if (fixed_k < -lim) fixed_k = -lim;
-
-    pIntFrame->frame.b1 = fixed_b1;
-    pIntFrame->frame.b2 = fixed_b2;
-    pIntFrame->frame.k = fixed_k;
+    pIntFrame->frame.b1 = b1;
+    pIntFrame->frame.b02 = b02;
+    pIntFrame->frame.a1 = a1;
+    pIntFrame->frame.a2 = a2;
 }
-#endif
 #endif
 

--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -28,7 +28,9 @@
 */
 
 // includes
+#define _USE_MATH_DEFINES
 #include <math.h>
+
 #define LOG_TAG "SYNTH"
 #include "log/log.h"
 #include <cutils/log.h>

--- a/arm-wt-22k/lib_src/eas_wtsynth.h
+++ b/arm-wt-22k/lib_src/eas_wtsynth.h
@@ -30,37 +30,8 @@
 #ifndef _EAS_WTSYNTH_H
 #define _EAS_WTSYNTH_H
 
-#include "eas_sndlib.h"
 #include "eas_wtengine.h"
-
-/* adjust the filter cutoff frequency to the sample rate */
-#if defined (_SAMPLE_RATE_8000)
-#define FILTER_CUTOFF_FREQ_ADJUST       0
-#elif defined (_SAMPLE_RATE_16000)
-#define FILTER_CUTOFF_FREQ_ADJUST       1200
-#elif defined (_SAMPLE_RATE_20000)
-#define FILTER_CUTOFF_FREQ_ADJUST       1586
-#elif defined (_SAMPLE_RATE_22050)
-#define FILTER_CUTOFF_FREQ_ADJUST       1756
-#elif defined (_SAMPLE_RATE_24000)
-#define FILTER_CUTOFF_FREQ_ADJUST       1902
-#elif defined (_SAMPLE_RATE_32000)
-#define FILTER_CUTOFF_FREQ_ADJUST       2400
-#elif defined (_SAMPLE_RATE_44100)
-#define FILTER_CUTOFF_FREQ_ADJUST       2956
-#elif defined (_SAMPLE_RATE_48000)
-#define FILTER_CUTOFF_FREQ_ADJUST       3102
-#else
-#error "_SAMPLE_RATE_XXXXX must be defined to valid rate"
-#endif
 
 /* function prototypes */
 void WT_UpdateLFO (S_LFO_CONTROL *pLFO, EAS_I16 phaseInc);
-
-#if defined(_FILTER_ENABLED) || defined(DLS_SYNTHESIZER)
-void WT_SetFilterCoeffs (S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance);
 #endif
-
-#endif
-
-

--- a/example/sonivoxrender.1
+++ b/example/sonivoxrender.1
@@ -7,7 +7,7 @@ audio
 .SH SYNOPSIS
 .PP
 \f[B]sonivoxrender\f[R] [\f[B]\-h|\-\-help\f[R]]
-[\f[B]\-v|\-\-version\f[R]] [\f[B]\-d|\-\-dls\f[R] \f[I]file.dls\f[R]]
+[\f[B]\-v|\-\-version\f[R]] [\f[B]\-d|\-\-dls\f[R] \f[I]soundfont\f[R]]
 [\f[B]\-r|\-\-reverb\f[R] \f[I]0..4\f[R]] [\f[B]\-w|\-\-wet\f[R]
 \f[I]0..32767\f[R]] [\f[B]\-n|\-\-dry\f[R] \f[I]0..32767\f[R]]
 [\f[B]\-c|\-\-chorus\f[R] \f[I]0..4\f[R]] [\f[B]\-l|\-\-level\f[R]
@@ -28,8 +28,8 @@ Prints brief usage information.
 \-v, \-\-version
 Prints the version numbers.
 .TP
-\-d, \-\-dls \f[I]file.dls\f[R]
-Optional DLS soundfont file name.
+\-d, \-\-dls \f[I]soundfont\f[R]
+Optional DLS or SF2 soundfont file name.
 If not provided, it uses an internal embedded soundfont.
 .TP
 \-r, \-\-reverb \f[I]reverb_preset\f[R]

--- a/example/sonivoxrender.1.md
+++ b/example/sonivoxrender.1.md
@@ -7,7 +7,7 @@
 
 # SYNOPSIS
 
-| **sonivoxrender** [**-h|-\-help**] [**-v|-\-version**] [**-d|-\-dls** _file.dls_] [**-r|-\-reverb** _0..4_] [**-w|-\-wet** _0..32767_] [**-n|-\-dry** _0..32767_] [**-c|-\-chorus** _0..4_] [**-l|-\-level** _0..32767_] [**-g|-\-gain** _0..196_] [**-V|-\-Verbosity** _0..5_] [**-R|-\-reverb-post-mix**] [**-C|-\-chorus-post-mix**] _midi_file_
+| **sonivoxrender** [**-h|-\-help**] [**-v|-\-version**] [**-d|-\-dls** _soundfont_] [**-r|-\-reverb** _0..4_] [**-w|-\-wet** _0..32767_] [**-n|-\-dry** _0..32767_] [**-c|-\-chorus** _0..4_] [**-l|-\-level** _0..32767_] [**-g|-\-gain** _0..196_] [**-V|-\-Verbosity** _0..5_] [**-R|-\-reverb-post-mix**] [**-C|-\-chorus-post-mix**] _midi_file_
 
 # DESCRIPTION
 
@@ -24,9 +24,9 @@ It reads .MID (Standard MIDI Files) file format, and writes an audio stream to t
 
 :   Prints the version numbers.
 
--d, -\-dls  _file.dls_
+-d, -\-dls  _soundfont_
 
-:   Optional DLS soundfont file name. If not provided, it uses an internal embedded soundfont.
+:   Optional DLS or SF2 soundfont file name. If not provided, it uses an internal embedded soundfont.
 
 -r, -\-reverb  _reverb_preset_
 

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -359,7 +359,7 @@ int main (int argc, char **argv)
         case 'h':
             fprintf(
                 stderr,
-                "Usage: %s [-h|--help] [-v|--version] [-d|--dls file.dls] [-r|--reverb 0..4] "
+                "Usage: %s [-h|--help] [-v|--version] [-d|--dls soundfont] [-r|--reverb 0..4] "
                 "[-w|--wet 0..32767] [-n|--dry 0..32767] "
                 "[-c|--chorus 0..4] [-l|--level 0..32767] [-g|--gain 0..196] [-V|--Verbosity "
                 "0..5] [-R|--reverb-post-mix] [-C|--chorus-post-mix] file.mid ...\n"
@@ -367,7 +367,7 @@ int main (int argc, char **argv)
                 "Options:\n"
                 "\t-h, --help\t\tthis help message.\n"
                 "\t-v, --version\t\tsonivox version.\n"
-                "\t-d, --dls file.dls\tDLS soundfont.\n"
+                "\t-d, --dls soundfont\tDLS or SF2 soundfont.\n"
                 "\t-r, --reverb n\t\treverb preset: 0=no, 1=large hall, 2=hall, 3=chamber, "
                 "4=room.\n"
                 "\t-w, --wet n\t\treverb wet: 0..32767.\n"


### PR DESCRIPTION
## Description

Implement SoundFont 2 parser and rewrite DCF (Digital Controlled Filter).

This is not a complete implementation. It still uses the DLS synth. [SF3 by Werner Schweer](https://github.com/FluidSynth/fluidsynth/wiki/SoundFont3Format) is recognized, though not supported.

The DCF now supports cutoff up to nyquist frequency (22050hz here), which is necessary for SF2 (DLS only requires up to SR/6, 7350hz here).

This PR also adds an example of mpv to README.md. mpv supports navigation in memory cache and progress view.

---

/usr/share/dmidiplayer/Schubert_Standchen.mid, 8Rock11e.sf2

https://github.com/user-attachments/assets/72bcfcd3-945a-4d82-87e4-d67bf9e52e95

[Field of Hopes and Dreams.rmi from spessasus/spessasynth-demo-songs](https://github.com/spessasus/spessasynth-demo-songs/raw/refs/heads/main/demo_songs/Field%20of%20Hopes%20and%20Dreams.rmi) (split into SMF and SF2 as SF3 is unsupported)

https://github.com/user-attachments/assets/bdc85fdc-132d-4cb4-953c-336d811f96ed


Tested with https://github.com/mrbumpy409/SoundFont-Spec-Test, works.


## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

