### PR TITLE
Fix last region flag existing in key group

### DIFF
--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -2122,7 +2122,7 @@ static EAS_RESULT Parse_rgnh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, S_DL
     pRgn->wtRegion.region.rangeHigh = (EAS_U8) highKey;
 
     /*lint -e{734} keyGroup will always be from 0-15 */
-    pRgn->wtRegion.region.keyGroupAndFlags = keyGroup << 8;
+    pRgn->wtRegion.region.keyGroupAndFlags = (keyGroup & 0x7f) << 8;
     pRgn->velLow = (EAS_U8) lowVel;
     pRgn->velHigh = (EAS_U8) highVel;
     if (optionFlags & F_RGN_OPTION_SELFNONEXCLUSIVE)

--- a/arm-wt-22k/lib_src/eas_sf2.c
+++ b/arm-wt-22k/lib_src/eas_sf2.c
@@ -1902,11 +1902,11 @@ static EAS_RESULT Parse_bag(S_SF2_PARSER* pParser, const EAS_I16 gens[sfg_endOpe
         *loopMode = 0;
     }
 
-    if (gens[sfg_exclusiveClass] > 0xFF) {
+    if (gens[sfg_exclusiveClass] > 0x7f) {
         EAS_Report(_EAS_SEVERITY_WARNING, "SF2Parser: exclusive class number %u is too large at generator entry\n", gens[sfg_exclusiveClass]);
         pDLSRegion->wtRegion.region.keyGroupAndFlags = REGION_FLAG_NON_SELF_EXCLUSIVE;
     } else {
-        pDLSRegion->wtRegion.region.keyGroupAndFlags = ((EAS_U8)gens[sfg_exclusiveClass] << 8) | REGION_FLAG_NON_SELF_EXCLUSIVE;
+        pDLSRegion->wtRegion.region.keyGroupAndFlags = ((gens[sfg_exclusiveClass] & 0x7f) << 8) | REGION_FLAG_NON_SELF_EXCLUSIVE;
     }
 
     // modulators

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -84,7 +84,7 @@ typedef struct s_region_tag
 /*
  * Bit fields for m_nKeyGroupAndFlags
  * Bits 0-2 are mode bits in FM synth
- * Bits 8-11 are the key group
+ * Bits 8-15 are the key group
  */
 #define REGION_FLAG_IS_LOOPED                   0x01
 #define REGION_FLAG_USE_WAVE_GENERATOR          0x02
@@ -93,7 +93,7 @@ typedef struct s_region_tag
 #define REGION_FLAG_SQUARE_WAVE                 0x10
 #define REGION_FLAG_OFF_CHIP                    0x20
 #define REGION_FLAG_NON_SELF_EXCLUSIVE          0x40
-#define REGION_FLAG_LAST_REGION                 0x8000
+#define REGION_FLAG_LAST_REGION                 0x80
 
 /*----------------------------------------------------------------------------
  * Envelope data structure

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -83,8 +83,8 @@ typedef struct s_region_tag
 
 /*
  * Bit fields for m_nKeyGroupAndFlags
- * Bits 0-2 are mode bits in FM synth
- * Bits 8-15 are the key group
+ * Bits 0-7 are flags
+ * Bits 8-14 are the key group
  */
 #define REGION_FLAG_IS_LOOPED                   0x01
 #define REGION_FLAG_USE_WAVE_GENERATOR          0x02
@@ -93,7 +93,8 @@ typedef struct s_region_tag
 #define REGION_FLAG_SQUARE_WAVE                 0x10
 #define REGION_FLAG_OFF_CHIP                    0x20
 #define REGION_FLAG_NON_SELF_EXCLUSIVE          0x40
-#define REGION_FLAG_LAST_REGION                 0x80
+#define REGION_FLAG_LAST_REGION                 0x8000
+#define REGION_KEY_GROUP_MASK                   0x7f00
 
 /*----------------------------------------------------------------------------
  * Envelope data structure

--- a/arm-wt-22k/lib_src/eas_voicemgt.c
+++ b/arm-wt-22k/lib_src/eas_voicemgt.c
@@ -1591,7 +1591,7 @@ void VMCheckKeyGroup (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, EAS_U16 keyGroup,
             {
                 /* check key group */
                 pRegion = GetRegionPtr(pSynth, pVoiceMgr->voices[voiceNum].regionIndex);
-                if (keyGroup == (pRegion->keyGroupAndFlags >> 8))
+                if (keyGroup == (pRegion->keyGroupAndFlags & REGION_KEY_GROUP_MASK))
                 {
 #ifdef _DEBUG_VM
                     { /* dpp: EAS_ReportEx(_EAS_SEVERITY_INFO, "VMCheckKeyGroup: voice %d matches key group %d\n", voiceNum, keyGroup >> 8); */ }
@@ -1616,7 +1616,7 @@ void VMCheckKeyGroup (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, EAS_U16 keyGroup,
             {
                 /* check key group */
                 pRegion = GetRegionPtr(pSynth, pVoiceMgr->voices[voiceNum].nextRegionIndex);
-                if (keyGroup == (pRegion->keyGroupAndFlags >> 8))
+                if (keyGroup == (pRegion->keyGroupAndFlags & REGION_KEY_GROUP_MASK))
                 {
 #ifdef _DEBUG_VM
                     { /* dpp: EAS_ReportEx(_EAS_SEVERITY_INFO, "VMCheckKeyGroup: voice %d matches key group %d\n", voiceNum, keyGroup >> 8); */ }
@@ -1778,8 +1778,8 @@ void VMStartVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, EAS_U8 channel, EAS_
     {
 
         /* check for key group exclusivity */
-        keyGroup = pRegion->keyGroupAndFlags >> 8;
-        if (keyGroup!= 0)
+        keyGroup = pRegion->keyGroupAndFlags & REGION_KEY_GROUP_MASK;
+        if (keyGroup != 0)
             VMCheckKeyGroup(pVoiceMgr, pSynth, keyGroup, channel);
 
         /* check polyphony limit and steal a voice if necessary */


### PR DESCRIPTION
## Description

This PR fixes the REGION_FLAG_LAST_REGION which is overlapped with key group.

## Related Issues

Fix #88 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

