### PR TITLE
Fix 8-bit WT synth and original DCF

### DIFF
--- a/arm-wt-22k/lib_src/eas_filter.c
+++ b/arm-wt-22k/lib_src/eas_filter.c
@@ -3,6 +3,7 @@
 #include "eas_report.h"
 #include "eas_audioconst.h"
 #include "eas_math.h"
+#include "eas_synth.h"
 
 #include "log/log.h"
 #include <cutils/log.h>
@@ -298,6 +299,15 @@ static const EAS_I16 n1g3[] =
 void WT_SetFilterCoeffs (S_WT_INT_FRAME *pIntFrame, EAS_I32 cutoff, EAS_I32 resonance)
 {
     EAS_I32 temp;
+
+    /* subtract the A5 offset and the sampling frequency */
+    cutoff -= FILTER_CUTOFF_FREQ_ADJUST + A5_PITCH_OFFSET_IN_CENTS;
+
+    /* limit the cutoff frequency */
+    if (cutoff > FILTER_CUTOFF_MAX_PITCH_CENTS)
+        cutoff = FILTER_CUTOFF_MAX_PITCH_CENTS;
+    else if (cutoff < FILTER_CUTOFF_MIN_PITCH_CENTS)
+        cutoff = FILTER_CUTOFF_MIN_PITCH_CENTS;
 
     /*
     Convert the cutoff, which has had A5 subtracted, using the 2^x approx

--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -399,7 +399,11 @@ static EAS_RESULT WT_StartVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNT
         else
             pWTVoice->phaseAccum = pSynth->pEAS->pSampleOffsets[pRegion->waveIndex];
 #else
-        pWTVoice->phaseAccum = pSynth->pEAS->pSamples + pSynth->pEAS->pSampleOffsets[pRegion->waveIndex]/2;
+#if defined (_8_BIT_SAMPLES)
+        pWTVoice->phaseAccum = pSynth->pEAS->pSamples + pSynth->pEAS->pSampleOffsets[pRegion->waveIndex];
+#else //_16_BIT_SAMPLES
+        pWTVoice->phaseAccum = pSynth->pEAS->pSamples + (pSynth->pEAS->pSampleOffsets[pRegion->waveIndex] / 2);
+#endif
 #endif
 
         if (pRegion->region.keyGroupAndFlags & REGION_FLAG_IS_LOOPED)
@@ -554,7 +558,8 @@ static EAS_BOOL WT_UpdateVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNTH
     WT_UpdateLFO(&pWTVoice->modLFO, pArt->lfoFreq);
 
 #ifdef _FILTER_ENABLED
-    /* calculate filter if library uses filter */
+/*
+    // calculate filter if library uses filter //
     if (pSynth->pEAS->libAttr & LIB_FORMAT_FILTER_ENABLED) {
         WT_UpdateFilter(pWTVoice, &intFrame, pArt);
     } else {
@@ -564,6 +569,9 @@ static EAS_BOOL WT_UpdateVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNTH
         intFrame.frame.k = 0;
 #endif
     }
+*/
+    // The LIB_FORMAT_FILTER_ENABLED flag is just bogus. It seems to be 8-bit samples flag.
+    WT_UpdateFilter(pWTVoice, &intFrame, pArt);
 #endif
 
     /* update the gain */


### PR DESCRIPTION
## Description

* Fix a bug about phaseAccum when using 8-bit samples
* Fix original DCF coef calculations
* Fix a bug that DCF for 16-bit WT is not enabled

## Related Issues

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

