### PR TITLE
Improve program substituting and its logging

### DIFF
--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -1777,7 +1777,7 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     {
         EAS_Report(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08x\n", bank);
     }
-    if (bank & 0x80000000u)
+    if (bank & 0x80000000u || (bank & 0x7f7f) == DEFAULT_RHYTHM_BANK_NUMBER)
     {
         /* drum instrument */
         bank &= 0x7f7f;

--- a/arm-wt-22k/lib_src/eas_mdls.c
+++ b/arm-wt-22k/lib_src/eas_mdls.c
@@ -1777,7 +1777,7 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
     {
         EAS_Report(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08x\n", bank);
     }
-    if (bank & 0x80000000u || (bank & 0x7f7f) == DEFAULT_RHYTHM_BANK_NUMBER)
+    if (bank & 0x80000000u || (bank & 0x7f00) == DEFAULT_RHYTHM_BANK_NUMBER)
     {
         /* drum instrument */
         bank &= 0x7f7f;

--- a/arm-wt-22k/lib_src/eas_sndlib.h
+++ b/arm-wt-22k/lib_src/eas_sndlib.h
@@ -287,7 +287,7 @@ typedef struct s_fm_region_tag
 */
 typedef struct s_program_tag
 {
-    EAS_U32 locale;
+    EAS_U32 locale; // 0xdmmllpp d=0(melodic)/1(drums) (only exist in DLS programs), mm=bank MSB, ll=bank LSB, pp=program
     EAS_U16 regionIndex;
 } S_PROGRAM;
 

--- a/arm-wt-22k/lib_src/eas_voicemgt.c
+++ b/arm-wt-22k/lib_src/eas_voicemgt.c
@@ -2831,21 +2831,7 @@ subst:
         }
     }
 
-    // 4. for drums, bank to DEFAULT_RHYTHM_BANK_NUMBER but don't check drum flag
-    if ((bank & 0x1FF00) == (0x10000 | DEFAULT_RHYTHM_BANK_NUMBER)) {
-        locale = (DEFAULT_RHYTHM_BANK_NUMBER << 8) | program;
-
-        for (i = 0, p = pDLS->pDLSPrograms; i < pDLS->numDLSPrograms; i++, p++)
-        {
-            if (p->locale == locale)
-            {
-                *pRegionIndex = p->regionIndex;
-                goto subst_success;
-            }
-        }
-    }
-
-    // 5. for drums, pc to 0
+    // 4. for drums, pc to 0
     if ((bank & 0x10000) && program != 0)
     {
         program = 0;


### PR DESCRIPTION
## Description

Improve program substituting and its logging. Now [drum=1, bank=120/0] can fallback to [drum=0, bank=120/0].

After:
```
VMFindDLSProgram: Program [drum=1, bank=120/0, pc=0] not found, subst [drum=0, bank=120/0, pc=0]
VMFindDLSProgram: Program [drum=1, bank=120/0, pc=0] not found, subst [drum=0, bank=120/0, pc=0]
VMFindDLSProgram: Program [drum=1, bank=120/0, pc=0] not found, subst [drum=0, bank=120/0, pc=0]
VMFindDLSProgram: Program [drum=0, bank=121/0, pc=18] not found, subst WT
VMFindDLSProgram: Program [drum=0, bank=121/0, pc=29] not found, subst WT
VMFindDLSProgram: Program [drum=0, bank=121/0, pc=81] not found, subst WT
VMFindDLSProgram: Program [drum=0, bank=121/0, pc=81] not found, subst WT
```

## Related Issues

Partially *fix* for 🪲 #93

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

