### PR TITLE
Fix DLG EG decaying (bug #93)

### DIFF
--- a/arm-wt-22k/lib_src/eas_dlssynth.c
+++ b/arm-wt-22k/lib_src/eas_dlssynth.c
@@ -580,7 +580,7 @@ static void DLS_UpdateEnvelope (S_SYNTH_VOICE *pVoice, S_SYNTH_CHANNEL *pChannel
                     // very small decay time, regard it as no decay
                     goto nodecay;
                 }
-                *pIncrement = (SYNTH_FULL_SCALE_EG1_GAIN - pEnvParams->sustainLevel) / temp;
+                *pIncrement = SYNTH_FULL_SCALE_EG1_GAIN / temp;
                 if (*pIncrement == 0) {
                     *pIncrement = 1; // ensure no infinite decay
                 }


### PR DESCRIPTION

## Description

https://github.com/pedrolcl/sonivox/issues/93#issuecomment-3418411306

> After some investigation about the EG and DLS specification, it seems that decay time is misinterpreted in the PR https://github.com/pedrolcl/sonivox/pull/74 (which introduced this bug). Decay time is defined as 100% decay time, but https://github.com/pedrolcl/sonivox/pull/74 made EG always end decaying in decay time.
## Related Issues

Fix #93

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

